### PR TITLE
feat: Streamlit UI — upload, query, meetings pages

### DIFF
--- a/src/ui/api_client.py
+++ b/src/ui/api_client.py
@@ -1,0 +1,78 @@
+"""HTTP client wrapper for the Meeting Intelligence FastAPI backend."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import streamlit as st
+
+API_URL = os.getenv("API_URL", "http://localhost:8000")
+
+
+def check_health() -> bool:
+    """Return True if the API server responds to /health."""
+    try:
+        r = httpx.get(f"{API_URL}/health", timeout=5.0)
+        return r.status_code == 200
+    except httpx.ConnectError:
+        return False
+
+
+def upload_transcript(
+    file_content: bytes,
+    filename: str,
+    title: str,
+    chunking_strategy: str = "speaker_turn",
+) -> dict:  # type: ignore[type-arg]
+    """Upload a transcript file to the ingestion endpoint."""
+    try:
+        r = httpx.post(
+            f"{API_URL}/api/ingest",
+            files={"file": (filename, file_content)},
+            data={"title": title, "chunking_strategy": chunking_strategy},
+            timeout=120.0,
+        )
+        r.raise_for_status()
+        return r.json()  # type: ignore[no-any-return]
+    except httpx.HTTPError as e:
+        st.error(f"Upload failed: {e}")
+        return {}
+
+
+def query_meetings(
+    question: str,
+    meeting_id: str | None = None,
+    strategy: str = "hybrid",
+) -> dict:  # type: ignore[type-arg]
+    """Send a question to the query endpoint."""
+    try:
+        payload: dict[str, str] = {"question": question, "strategy": strategy}
+        if meeting_id:
+            payload["meeting_id"] = meeting_id
+        r = httpx.post(f"{API_URL}/api/query", json=payload, timeout=60.0)
+        r.raise_for_status()
+        return r.json()  # type: ignore[no-any-return]
+    except httpx.HTTPError as e:
+        st.error(f"Query failed: {e}")
+        return {}
+
+
+def get_meetings() -> list[dict]:  # type: ignore[type-arg]
+    """Fetch the list of all ingested meetings."""
+    try:
+        r = httpx.get(f"{API_URL}/api/meetings", timeout=10.0)
+        r.raise_for_status()
+        return r.json()  # type: ignore[no-any-return]
+    except httpx.HTTPError:
+        return []
+
+
+def get_meeting_detail(meeting_id: str) -> dict:  # type: ignore[type-arg]
+    """Fetch detailed information for a single meeting."""
+    try:
+        r = httpx.get(f"{API_URL}/api/meetings/{meeting_id}", timeout=10.0)
+        r.raise_for_status()
+        return r.json()  # type: ignore[no-any-return]
+    except httpx.HTTPError:
+        return {}

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,21 +1,213 @@
-import os
+"""Meeting Intelligence -- Streamlit UI.
 
-import httpx
+Multi-page application for uploading meeting transcripts, asking questions,
+and browsing ingested meetings.
+"""
+
+from __future__ import annotations
+
 import streamlit as st
 
-API_URL = os.getenv("API_URL", "http://localhost:8000")
+from src.ui.api_client import (
+    check_health,
+    get_meeting_detail,
+    get_meetings,
+    query_meetings,
+    upload_transcript,
+)
 
+# ---------------------------------------------------------------------------
+# Page config (must be first Streamlit call)
+# ---------------------------------------------------------------------------
 st.set_page_config(page_title="Meeting Intelligence", layout="wide")
-st.title("Meeting Intelligence")
 
-# Health check
-try:
-    response = httpx.get(f"{API_URL}/health", timeout=5.0)
-    if response.status_code == 200:
-        st.success("API connected")
+# ---------------------------------------------------------------------------
+# Sidebar -- navigation + API status
+# ---------------------------------------------------------------------------
+with st.sidebar:
+    st.title("Meeting Intelligence")
+    st.markdown("---")
+
+    page = st.radio(
+        "Navigate",
+        ["Upload Meeting", "Ask Questions", "Meetings"],
+        label_visibility="collapsed",
+    )
+
+    st.markdown("---")
+
+    # API connection indicator
+    api_healthy = check_health()
+    if api_healthy:
+        st.markdown(":green_circle: API connected")
     else:
-        st.error(f"API returned {response.status_code}")
-except httpx.ConnectError:
-    st.warning("API not reachable. Start the API server first.")
+        st.markdown(":red_circle: API unreachable")
 
-st.info("Upload a meeting transcript or ask questions about your meetings.")
+# ---------------------------------------------------------------------------
+# Page: Upload Meeting
+# ---------------------------------------------------------------------------
+if page == "Upload Meeting":
+    st.header("Upload Meeting")
+    st.write("Upload a transcript or audio file to ingest into the system.")
+
+    uploaded_file = st.file_uploader(
+        "Choose a file",
+        type=["vtt", "txt", "json", "mp3", "wav", "m4a"],
+    )
+
+    title = st.text_input("Meeting title", placeholder="e.g. Sprint Planning 2026-02-18")
+
+    chunking_strategy = st.selectbox(
+        "Chunking strategy",
+        options=["speaker_turn", "naive"],
+        format_func=lambda x: "Speaker-turn" if x == "speaker_turn" else "Naive",
+    )
+
+    # Inform users about audio transcription
+    if uploaded_file is not None and uploaded_file.name.split(".")[-1] in {
+        "mp3",
+        "wav",
+        "m4a",
+    }:
+        st.info(
+            "Audio files will be transcribed using AssemblyAI with speaker diarization. "
+            "This may take a few minutes depending on the file length."
+        )
+
+    if st.button("Upload", disabled=uploaded_file is None or not title):
+        if not api_healthy:
+            st.error("Cannot upload: the API server is not reachable.")
+        elif uploaded_file is not None and title:
+            with st.spinner("Uploading and processing..."):
+                result = upload_transcript(
+                    file_content=uploaded_file.getvalue(),
+                    filename=uploaded_file.name,
+                    title=title,
+                    chunking_strategy=str(chunking_strategy),
+                )
+            if result:
+                st.success("Meeting uploaded successfully.")
+                if "meeting_id" in result:
+                    st.write(f"**Meeting ID:** {result['meeting_id']}")
+                if "num_chunks" in result:
+                    st.write(f"**Chunks created:** {result['num_chunks']}")
+            # Error case is already handled inside upload_transcript via st.error
+
+# ---------------------------------------------------------------------------
+# Page: Ask Questions
+# ---------------------------------------------------------------------------
+elif page == "Ask Questions":
+    st.header("Ask Questions")
+    st.write("Ask a natural-language question about your ingested meetings.")
+
+    # Fetch meetings for the optional filter
+    meetings_list = get_meetings() if api_healthy else []
+
+    question = st.text_input(
+        "Your question", placeholder="What were the action items from the last standup?"
+    )
+
+    col1, col2 = st.columns(2)
+    with col1:
+        meeting_options: dict[str, str | None] = {"All meetings": None}
+        for m in meetings_list:
+            label = m.get("title", m.get("id", "Unknown"))
+            meeting_options[label] = m.get("id")
+        selected_meeting_label = st.selectbox(
+            "Filter by meeting (optional)", options=list(meeting_options.keys())
+        )
+        selected_meeting_id = meeting_options[selected_meeting_label]
+
+    with col2:
+        strategy = st.selectbox(
+            "Retrieval strategy (optional)",
+            options=["hybrid", "semantic"],
+            format_func=lambda x: x.capitalize(),
+        )
+
+    if st.button("Ask", disabled=not question):
+        if not api_healthy:
+            st.error("Cannot query: the API server is not reachable.")
+        elif question:
+            with st.spinner("Searching and generating answer..."):
+                result = query_meetings(
+                    question=question,
+                    meeting_id=str(selected_meeting_id) if selected_meeting_id else None,
+                    strategy=str(strategy),
+                )
+            if result:
+                # Display the generated answer
+                st.subheader("Answer")
+                st.markdown(result.get("answer", "No answer returned."))
+
+                # Display source chunks
+                sources = result.get("sources", [])
+                if sources:
+                    st.subheader("Sources")
+                    for i, src in enumerate(sources, 1):
+                        with st.expander(
+                            f"Source {i} -- {src.get('meeting_title', 'Unknown meeting')}"
+                        ):
+                            if "speaker" in src:
+                                st.write(f"**Speaker:** {src['speaker']}")
+                            if "timestamp" in src:
+                                st.write(f"**Timestamp:** {src['timestamp']}")
+                            if "similarity" in src:
+                                st.write(f"**Similarity:** {src['similarity']:.4f}")
+                            st.markdown("---")
+                            st.write(src.get("text", ""))
+
+# ---------------------------------------------------------------------------
+# Page: Meetings
+# ---------------------------------------------------------------------------
+elif page == "Meetings":
+    st.header("Meetings")
+    st.write("Browse all ingested meetings.")
+
+    if not api_healthy:
+        st.warning("The API server is not reachable. Cannot load meetings.")
+    else:
+        meetings_list = get_meetings()
+        if not meetings_list:
+            st.info("No meetings found. Upload a transcript to get started.")
+        else:
+            for meeting in meetings_list:
+                meeting_title = meeting.get("title", "Untitled")
+                meeting_id = meeting.get("id", "")
+                date = meeting.get("date", "N/A")
+                num_speakers = meeting.get("num_speakers", "N/A")
+                num_chunks = meeting.get("num_chunks", "N/A")
+
+                with st.expander(f"{meeting_title}"):
+                    col_a, col_b, col_c = st.columns(3)
+                    col_a.metric("Date", date)
+                    col_b.metric("Speakers", str(num_speakers))
+                    col_c.metric("Chunks", str(num_chunks))
+
+                    # Fetch detail on expand
+                    detail = get_meeting_detail(meeting_id)
+                    if detail:
+                        # Action items
+                        action_items = detail.get("action_items", [])
+                        if action_items:
+                            st.subheader("Action Items")
+                            for item in action_items:
+                                owner = item.get("owner", "Unassigned")
+                                text = item.get("text", "")
+                                st.write(f"- **{owner}:** {text}")
+
+                        # Decisions
+                        decisions = detail.get("decisions", [])
+                        if decisions:
+                            st.subheader("Decisions")
+                            for dec in decisions:
+                                st.write(f"- {dec.get('text', '')}")
+
+                        # Topics
+                        topics = detail.get("topics", [])
+                        if topics:
+                            st.subheader("Topics")
+                            st.write(", ".join(topics))
+
+                        if not action_items and not decisions and not topics:
+                            st.write("No extracted items available yet.")


### PR DESCRIPTION
## Summary
- Multi-page Streamlit app with sidebar navigation
- **Upload page**: file uploader (.vtt/.txt/.json/.mp3/.wav/.m4a), chunking strategy selector, AssemblyAI transcription note for audio
- **Ask Questions page**: query input, meeting filter, strategy toggle (Hybrid/Semantic), answer display with source chunks
- **Meetings page**: list view with expandable cards, extracted items display
- HTTP client wrapper (`api_client.py`) for all FastAPI calls
- Graceful handling when API endpoints don't exist yet

## Dependencies
- Requires Issue #3 (Query pipeline + API endpoints) for full functionality
- Currently shows warnings when API endpoints are missing — no crashes

## Test plan
- [x] `ruff check src/ui/` — clean
- [x] `ruff format --check src/ui/` — formatted
- [ ] Manual: `streamlit run src/ui/app.py` — verifies app loads without crash
- [ ] Integration: full flow after Issue #3 merges

Closes #4