### PR TITLE
feat: ingestion pipeline — parsers, chunking, embedding, storage

### DIFF
--- a/src/ingestion/__init__.py
+++ b/src/ingestion/__init__.py
@@ -1,0 +1,1 @@
+"""Ingestion pipeline — parsing, chunking, embedding, and storage."""

--- a/src/ingestion/chunking.py
+++ b/src/ingestion/chunking.py
@@ -1,0 +1,141 @@
+"""Chunking strategies for transcript segments."""
+
+from __future__ import annotations
+
+from src.ingestion.models import Chunk, TranscriptSegment
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token estimate: word count * 4/3 (≈ 1 token per 0.75 words)."""
+    return max(1, len(text.split()))
+
+
+def naive_chunk(
+    segments: list[TranscriptSegment],
+    chunk_size: int = 500,
+    overlap: int = 50,
+) -> list[Chunk]:
+    """Concatenate all text and split into fixed-size chunks by word count.
+
+    Token count is approximated as word count (rough but dependency-free).
+    Start/end times are preserved from the first/last contributing segment.
+
+    Args:
+        segments: Parsed transcript segments.
+        chunk_size: Target number of words per chunk.
+        overlap: Number of overlapping words between consecutive chunks.
+
+    Returns:
+        List of :class:`Chunk` instances with ``strategy="naive"``.
+    """
+    if not segments:
+        return []
+
+    # Build a flat list of (word, segment_index) pairs to track provenance
+    word_seg_pairs: list[tuple[str, int]] = []
+    for seg_idx, seg in enumerate(segments):
+        for word in seg.text.split():
+            word_seg_pairs.append((word, seg_idx))
+
+    if not word_seg_pairs:
+        return []
+
+    chunks: list[Chunk] = []
+    start = 0
+    chunk_idx = 0
+
+    while start < len(word_seg_pairs):
+        end = min(start + chunk_size, len(word_seg_pairs))
+        window = word_seg_pairs[start:end]
+
+        text = " ".join(w for w, _ in window)
+        first_seg_idx = window[0][1]
+        last_seg_idx = window[-1][1]
+
+        chunks.append(
+            Chunk(
+                content=text,
+                start_time=segments[first_seg_idx].start_time,
+                end_time=segments[last_seg_idx].end_time,
+                chunk_index=chunk_idx,
+                strategy="naive",
+            )
+        )
+
+        chunk_idx += 1
+        start += chunk_size - overlap
+        # Prevent infinite loop when overlap >= chunk_size
+        if chunk_size - overlap <= 0:
+            start = end
+
+    return chunks
+
+
+def speaker_turn_chunk(
+    segments: list[TranscriptSegment],
+    max_chunk_tokens: int = 500,
+) -> list[Chunk]:
+    """Group consecutive segments by the same speaker.
+
+    If a single speaker turn exceeds *max_chunk_tokens* words it is split
+    into smaller chunks.
+
+    Args:
+        segments: Parsed transcript segments.
+        max_chunk_tokens: Maximum word count per chunk.
+
+    Returns:
+        List of :class:`Chunk` instances with ``strategy="speaker_turn"``.
+    """
+    if not segments:
+        return []
+
+    # Group consecutive segments by speaker
+    groups: list[tuple[str | None, list[TranscriptSegment]]] = []
+    for seg in segments:
+        if groups and groups[-1][0] == seg.speaker:
+            groups[-1][1].append(seg)
+        else:
+            groups.append((seg.speaker, [seg]))
+
+    chunks: list[Chunk] = []
+    chunk_idx = 0
+
+    for speaker, group_segs in groups:
+        combined_text = " ".join(s.text for s in group_segs)
+        start_time = group_segs[0].start_time
+        end_time = group_segs[-1].end_time
+
+        words = combined_text.split()
+
+        if _estimate_tokens(combined_text) <= max_chunk_tokens:
+            chunks.append(
+                Chunk(
+                    content=combined_text,
+                    speaker=speaker,
+                    start_time=start_time,
+                    end_time=end_time,
+                    chunk_index=chunk_idx,
+                    strategy="speaker_turn",
+                )
+            )
+            chunk_idx += 1
+        else:
+            # Split long turn into sub-chunks
+            pos = 0
+            while pos < len(words):
+                sub_words = words[pos : pos + max_chunk_tokens]
+                chunks.append(
+                    Chunk(
+                        content=" ".join(sub_words),
+                        speaker=speaker,
+                        start_time=start_time,
+                        end_time=end_time,
+                        chunk_index=chunk_idx,
+                        strategy="speaker_turn",
+                    )
+                )
+                chunk_idx += 1
+                pos += max_chunk_tokens
+
+    return chunks

--- a/src/ingestion/embeddings.py
+++ b/src/ingestion/embeddings.py
@@ -1,0 +1,36 @@
+"""Embedding helpers using OpenAI text-embedding-3-small."""
+
+from __future__ import annotations
+
+from openai import OpenAI
+
+from src.ingestion.models import Chunk
+
+
+def embed_texts(texts: list[str], model: str = "text-embedding-3-small") -> list[list[float]]:
+    """Embed a list of texts using the OpenAI embeddings API.
+
+    Args:
+        texts: Strings to embed.
+        model: OpenAI embedding model name.
+
+    Returns:
+        A list of embedding vectors (one per input text).
+    """
+    client = OpenAI()  # reads OPENAI_API_KEY from env
+    response = client.embeddings.create(input=texts, model=model)
+    return [item.embedding for item in response.data]
+
+
+def embed_chunks(chunks: list[Chunk]) -> list[tuple[Chunk, list[float]]]:
+    """Embed chunks and return ``(chunk, embedding)`` pairs.
+
+    Args:
+        chunks: Chunks whose ``content`` will be embedded.
+
+    Returns:
+        List of ``(Chunk, embedding_vector)`` tuples.
+    """
+    texts = [c.content for c in chunks]
+    embeddings = embed_texts(texts)
+    return list(zip(chunks, embeddings, strict=True))

--- a/src/ingestion/models.py
+++ b/src/ingestion/models.py
@@ -1,0 +1,27 @@
+"""Data models for the ingestion pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TranscriptSegment:
+    """Uniform representation of a transcript segment."""
+
+    speaker: str | None
+    text: str
+    start_time: float | None = None
+    end_time: float | None = None
+
+
+@dataclass
+class Chunk:
+    """A chunk ready for embedding and storage."""
+
+    content: str
+    speaker: str | None = None
+    start_time: float | None = None
+    end_time: float | None = None
+    chunk_index: int = 0
+    strategy: str = field(default="naive")

--- a/src/ingestion/parsers.py
+++ b/src/ingestion/parsers.py
@@ -1,0 +1,166 @@
+"""Transcript parsers for VTT, plain text, and JSON formats."""
+
+from __future__ import annotations
+
+import json
+import re
+
+from src.ingestion.models import TranscriptSegment
+
+
+def _parse_vtt_timestamp(ts: str) -> float:
+    """Convert a VTT timestamp (HH:MM:SS.mmm) to seconds."""
+    parts = ts.strip().split(":")
+    if len(parts) == 3:
+        hours, minutes, seconds = parts
+    elif len(parts) == 2:
+        hours = "0"
+        minutes, seconds = parts
+    else:
+        return 0.0
+    return int(hours) * 3600 + int(minutes) * 60 + float(seconds)
+
+
+def parse_vtt(content: str) -> list[TranscriptSegment]:
+    """Parse a WebVTT file into transcript segments.
+
+    Handles timestamps like ``00:01:23.456 --> 00:01:30.789`` and optional
+    speaker labels in the form ``Speaker 1: Hello``.
+    """
+    segments: list[TranscriptSegment] = []
+
+    # Pattern: timestamp line followed by one or more text lines
+    timestamp_re = re.compile(
+        r"(\d{1,2}:\d{2}:\d{2}[.,]\d{3})\s*-->\s*(\d{1,2}:\d{2}:\d{2}[.,]\d{3})"
+    )
+    speaker_re = re.compile(r"^(.+?):\s+(.+)$")
+
+    lines = content.strip().splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        match = timestamp_re.search(line)
+        if match:
+            start = _parse_vtt_timestamp(match.group(1).replace(",", "."))
+            end = _parse_vtt_timestamp(match.group(2).replace(",", "."))
+
+            # Collect text lines until blank line or next timestamp / end
+            text_lines: list[str] = []
+            i += 1
+            while i < len(lines) and lines[i].strip() and not timestamp_re.search(lines[i]):
+                text_lines.append(lines[i].strip())
+                i += 1
+
+            full_text = " ".join(text_lines)
+            speaker: str | None = None
+
+            # Check for speaker label
+            speaker_match = speaker_re.match(full_text)
+            if speaker_match:
+                speaker = speaker_match.group(1)
+                full_text = speaker_match.group(2)
+
+            if full_text:
+                segments.append(
+                    TranscriptSegment(
+                        speaker=speaker,
+                        text=full_text,
+                        start_time=start,
+                        end_time=end,
+                    )
+                )
+        else:
+            i += 1
+
+    return segments
+
+
+def parse_plain_text(content: str) -> list[TranscriptSegment]:
+    """Parse a plain-text transcript.
+
+    If lines start with ``Speaker X:`` the speaker is extracted, otherwise
+    speaker is ``None``.
+    """
+    segments: list[TranscriptSegment] = []
+    speaker_re = re.compile(r"^(.+?):\s+(.+)$")
+
+    for line in content.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+
+        match = speaker_re.match(line)
+        if match:
+            segments.append(TranscriptSegment(speaker=match.group(1), text=match.group(2)))
+        else:
+            segments.append(TranscriptSegment(speaker=None, text=line))
+
+    return segments
+
+
+def parse_json(content: str) -> list[TranscriptSegment]:
+    """Parse a JSON transcript (AssemblyAI or MeetingBank format).
+
+    AssemblyAI: ``{"utterances": [{"speaker": "A", "text": "...", "start": ms, "end": ms}]}``
+    MeetingBank: ``{"segments": [{"speaker": "...", "text": "...", "start_time": s, "end_time": s}]}``
+    """
+    data = json.loads(content)
+    segments: list[TranscriptSegment] = []
+
+    if "utterances" in data:
+        # AssemblyAI format — times in milliseconds
+        for utt in data["utterances"]:
+            segments.append(
+                TranscriptSegment(
+                    speaker=utt.get("speaker"),
+                    text=utt["text"],
+                    start_time=utt.get("start", 0) / 1000.0,
+                    end_time=utt.get("end", 0) / 1000.0,
+                )
+            )
+    elif "segments" in data:
+        # MeetingBank format — times in seconds
+        for seg in data["segments"]:
+            segments.append(
+                TranscriptSegment(
+                    speaker=seg.get("speaker"),
+                    text=seg["text"],
+                    start_time=seg.get("start_time"),
+                    end_time=seg.get("end_time"),
+                )
+            )
+    else:
+        msg = f"Unrecognized JSON transcript format. Keys: {list(data.keys())}"
+        raise ValueError(msg)
+
+    return segments
+
+
+def parse_transcript(content: str, format: str) -> list[TranscriptSegment]:
+    """Dispatch to the correct parser based on *format*.
+
+    Args:
+        content: Raw transcript text.
+        format: One of ``"vtt"``, ``"text"`` / ``"plain_text"`` / ``"txt"``,
+                or ``"json"``.
+
+    Returns:
+        Parsed transcript segments.
+
+    Raises:
+        ValueError: If *format* is not recognized.
+    """
+    dispatch: dict[str, object] = {
+        "vtt": parse_vtt,
+        "text": parse_plain_text,
+        "plain_text": parse_plain_text,
+        "txt": parse_plain_text,
+        "json": parse_json,
+    }
+
+    parser = dispatch.get(format)
+    if parser is None:
+        msg = f"Unknown transcript format: {format!r}. Supported: {list(dispatch.keys())}"
+        raise ValueError(msg)
+
+    return parser(content)  # type: ignore[operator]

--- a/src/ingestion/pipeline.py
+++ b/src/ingestion/pipeline.py
@@ -1,0 +1,49 @@
+"""End-to-end ingestion pipeline: parse -> chunk -> embed -> store."""
+
+from __future__ import annotations
+
+from src.ingestion.chunking import naive_chunk, speaker_turn_chunk
+from src.ingestion.embeddings import embed_chunks
+from src.ingestion.parsers import parse_transcript
+from src.ingestion.storage import get_supabase_client, store_chunks, store_meeting
+
+
+def ingest_transcript(
+    content: str,
+    format: str,
+    title: str,
+    chunking_strategy: str = "speaker_turn",
+) -> str:
+    """Full ingestion pipeline: parse -> chunk -> embed -> store.
+
+    Args:
+        content: Raw transcript text.
+        format: Transcript format (``"vtt"``, ``"json"``, ``"text"``).
+        title: Human-readable meeting title.
+        chunking_strategy: ``"naive"`` or ``"speaker_turn"``.
+
+    Returns:
+        The newly created meeting ID.
+    """
+    # 1. Parse
+    segments = parse_transcript(content, format)
+
+    # 2. Chunk
+    chunks = naive_chunk(segments) if chunking_strategy == "naive" else speaker_turn_chunk(segments)
+
+    # 3. Embed
+    chunks_with_embeddings = embed_chunks(chunks)
+
+    # 4. Store
+    client = get_supabase_client()
+    num_speakers = len({s.speaker for s in segments if s.speaker})
+    meeting_id = store_meeting(
+        client,
+        title,
+        content,
+        transcript_format=format,
+        num_speakers=num_speakers or None,
+    )
+    store_chunks(client, meeting_id, chunks_with_embeddings)
+
+    return meeting_id

--- a/src/ingestion/storage.py
+++ b/src/ingestion/storage.py
@@ -1,0 +1,73 @@
+"""Supabase storage helpers for meetings and chunks."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from supabase import Client, create_client
+
+if TYPE_CHECKING:
+    from src.ingestion.models import Chunk
+
+
+def get_supabase_client() -> Client:
+    """Create and return a Supabase client from environment variables."""
+    return create_client(
+        os.getenv("SUPABASE_URL", ""),
+        os.getenv("SUPABASE_KEY", ""),
+    )
+
+
+def store_meeting(
+    client: Client,
+    title: str,
+    raw_transcript: str,
+    source_file: str | None = None,
+    transcript_format: str | None = None,
+    duration_seconds: int | None = None,
+    num_speakers: int | None = None,
+) -> str:
+    """Store meeting metadata and return the generated meeting ID."""
+    result = (
+        client.table("meetings")
+        .insert(
+            {
+                "title": title,
+                "raw_transcript": raw_transcript,
+                "source_file": source_file,
+                "transcript_format": transcript_format,
+                "duration_seconds": duration_seconds,
+                "num_speakers": num_speakers,
+            }
+        )
+        .execute()
+    )
+    return str(result.data[0]["id"])
+
+
+def store_chunks(
+    client: Client,
+    meeting_id: str,
+    chunks_with_embeddings: list[tuple[Chunk, list[float]]],
+) -> None:
+    """Store chunks with embeddings in Supabase (batched by 50)."""
+    rows: list[dict[str, object]] = []
+    for chunk, embedding in chunks_with_embeddings:
+        rows.append(
+            {
+                "meeting_id": meeting_id,
+                "content": chunk.content,
+                "speaker": chunk.speaker,
+                "start_time": chunk.start_time,
+                "end_time": chunk.end_time,
+                "chunk_index": chunk.chunk_index,
+                "strategy": chunk.strategy,
+                "embedding": embedding,
+            }
+        )
+
+    # Insert in batches of 50
+    batch_size = 50
+    for i in range(0, len(rows), batch_size):
+        client.table("chunks").insert(rows[i : i + batch_size]).execute()

--- a/tests/fixtures/sample.vtt
+++ b/tests/fixtures/sample.vtt
@@ -1,0 +1,25 @@
+WEBVTT
+
+00:00:01.000 --> 00:00:08.000
+Mayor Johnson: Good evening everyone. I'd like to call this meeting to order.
+
+00:00:09.000 --> 00:00:18.000
+Council Member Davis: Thank you, Mayor. I move that we approve the minutes from last week's session.
+
+00:00:19.000 --> 00:00:25.000
+Mayor Johnson: We have a motion on the floor. All in favor?
+
+00:00:26.000 --> 00:00:30.000
+Council Member Smith: I second the motion. Aye.
+
+00:00:31.000 --> 00:00:45.000
+Mayor Johnson: Motion carries. Let's move to the first agenda item - the proposed budget for the downtown revitalization project.
+
+00:00:46.000 --> 00:01:10.000
+Council Member Davis: I've reviewed the budget proposal and I have some concerns about the allocation for infrastructure repairs. The current estimate of 2.3 million seems low given recent material cost increases.
+
+00:01:11.000 --> 00:01:30.000
+Council Member Park: I agree with Council Member Davis. We should also consider the environmental impact assessment costs which aren't reflected in the current budget.
+
+00:01:31.000 --> 00:01:50.000
+Mayor Johnson: These are valid concerns. I suggest we table the budget vote until next week and ask the finance committee to provide revised estimates.

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,206 @@
+"""Tests for the ingestion pipeline — parsers and chunking strategies."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.ingestion.chunking import naive_chunk, speaker_turn_chunk
+from src.ingestion.models import TranscriptSegment
+from src.ingestion.parsers import parse_json, parse_plain_text, parse_transcript, parse_vtt
+
+
+class TestVTTParser:
+    def test_basic_vtt(self) -> None:
+        vtt = """WEBVTT
+
+00:00:01.000 --> 00:00:05.000
+Speaker 1: Hello everyone, welcome to the meeting.
+
+00:00:05.500 --> 00:00:10.000
+Speaker 2: Thanks for having us. Let's get started.
+
+00:00:10.500 --> 00:00:15.000
+Speaker 1: First item on the agenda is the budget review.
+"""
+        segments = parse_vtt(vtt)
+        assert len(segments) == 3
+        assert segments[0].speaker == "Speaker 1"
+        assert segments[0].start_time == 1.0
+        assert "welcome" in segments[0].text
+
+    def test_vtt_no_speakers(self) -> None:
+        vtt = """WEBVTT
+
+00:00:01.000 --> 00:00:05.000
+Hello everyone.
+
+00:00:05.500 --> 00:00:10.000
+Let's get started.
+"""
+        segments = parse_vtt(vtt)
+        assert len(segments) == 2
+        assert segments[0].speaker is None
+
+    def test_vtt_end_times(self) -> None:
+        vtt = """WEBVTT
+
+00:00:01.000 --> 00:00:05.500
+Speaker A: Some text here.
+"""
+        segments = parse_vtt(vtt)
+        assert segments[0].end_time == 5.5
+
+    def test_vtt_multiline_cue(self) -> None:
+        vtt = """WEBVTT
+
+00:00:01.000 --> 00:00:05.000
+This is line one.
+This is line two.
+"""
+        segments = parse_vtt(vtt)
+        assert len(segments) == 1
+        assert "line one" in segments[0].text
+        assert "line two" in segments[0].text
+
+
+class TestPlainTextParser:
+    def test_with_speakers(self) -> None:
+        text = """Speaker 1: Hello everyone.
+Speaker 2: Hi there.
+Speaker 1: Let's begin."""
+        segments = parse_plain_text(text)
+        assert len(segments) == 3
+        assert segments[1].speaker == "Speaker 2"
+
+    def test_without_speakers(self) -> None:
+        text = """This is a meeting transcript.
+Nothing fancy here."""
+        segments = parse_plain_text(text)
+        assert len(segments) == 2
+        assert all(s.speaker is None for s in segments)
+
+    def test_empty_lines_ignored(self) -> None:
+        text = "Line one.\n\nLine two.\n\n"
+        segments = parse_plain_text(text)
+        assert len(segments) == 2
+
+
+class TestJSONParser:
+    def test_assemblyai_format(self) -> None:
+        data = json.dumps(
+            {
+                "utterances": [
+                    {"speaker": "A", "text": "Hello everyone.", "start": 1000, "end": 3000},
+                    {"speaker": "B", "text": "Hi there.", "start": 3500, "end": 5000},
+                ]
+            }
+        )
+        segments = parse_json(data)
+        assert len(segments) == 2
+        assert segments[0].speaker == "A"
+        assert segments[0].start_time == 1.0  # converted from ms
+        assert segments[0].end_time == 3.0
+
+    def test_meetingbank_format(self) -> None:
+        data = json.dumps(
+            {
+                "segments": [
+                    {"speaker": "X", "text": "Hello.", "start_time": 1.5, "end_time": 3.2},
+                    {"speaker": "Y", "text": "World.", "start_time": 3.5, "end_time": 5.0},
+                ]
+            }
+        )
+        segments = parse_json(data)
+        assert len(segments) == 2
+        assert segments[0].start_time == 1.5
+
+    def test_unknown_json_raises(self) -> None:
+        data = json.dumps({"something_else": []})
+        with pytest.raises(ValueError, match="Unrecognized JSON"):
+            parse_json(data)
+
+
+class TestNaiveChunking:
+    def test_produces_chunks(self) -> None:
+        segments = [
+            TranscriptSegment(speaker="A", text="Hello " * 100, start_time=0.0, end_time=10.0),
+            TranscriptSegment(speaker="B", text="World " * 100, start_time=10.0, end_time=20.0),
+        ]
+        chunks = naive_chunk(segments, chunk_size=100, overlap=10)
+        assert len(chunks) > 1
+        assert all(c.strategy == "naive" for c in chunks)
+
+    def test_preserves_times(self) -> None:
+        segments = [
+            TranscriptSegment(speaker="A", text="Short text.", start_time=5.0, end_time=10.0),
+        ]
+        chunks = naive_chunk(segments)
+        assert chunks[0].start_time == 5.0
+        assert chunks[0].end_time == 10.0
+
+    def test_chunk_indices_sequential(self) -> None:
+        segments = [
+            TranscriptSegment(speaker="A", text="word " * 300, start_time=0.0, end_time=60.0),
+        ]
+        chunks = naive_chunk(segments, chunk_size=100, overlap=10)
+        for i, c in enumerate(chunks):
+            assert c.chunk_index == i
+
+    def test_empty_segments(self) -> None:
+        assert naive_chunk([]) == []
+
+
+class TestSpeakerTurnChunking:
+    def test_groups_by_speaker(self) -> None:
+        segments = [
+            TranscriptSegment(speaker="A", text="Hello.", start_time=0.0, end_time=1.0),
+            TranscriptSegment(speaker="A", text="How are you?", start_time=1.0, end_time=2.0),
+            TranscriptSegment(speaker="B", text="I'm good.", start_time=2.0, end_time=3.0),
+        ]
+        chunks = speaker_turn_chunk(segments)
+        assert len(chunks) == 2  # A's two segments merged, B separate
+        assert chunks[0].speaker == "A"
+        assert chunks[1].speaker == "B"
+        assert all(c.strategy == "speaker_turn" for c in chunks)
+
+    def test_long_turn_split(self) -> None:
+        segments = [
+            TranscriptSegment(speaker="A", text="word " * 600, start_time=0.0, end_time=60.0),
+        ]
+        chunks = speaker_turn_chunk(segments, max_chunk_tokens=200)
+        assert len(chunks) > 1
+        assert all(c.speaker == "A" for c in chunks)
+
+    def test_preserves_times(self) -> None:
+        segments = [
+            TranscriptSegment(speaker="A", text="Hello.", start_time=5.0, end_time=8.0),
+            TranscriptSegment(speaker="A", text="World.", start_time=8.0, end_time=10.0),
+        ]
+        chunks = speaker_turn_chunk(segments)
+        assert chunks[0].start_time == 5.0
+        assert chunks[0].end_time == 10.0
+
+    def test_empty_segments(self) -> None:
+        assert speaker_turn_chunk([]) == []
+
+
+class TestParseDispatcher:
+    def test_vtt_dispatch(self) -> None:
+        vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:05.000\nHello."
+        segments = parse_transcript(vtt, "vtt")
+        assert len(segments) >= 1
+
+    def test_text_dispatch(self) -> None:
+        segments = parse_transcript("Hello world.", "text")
+        assert len(segments) == 1
+
+    def test_json_dispatch(self) -> None:
+        data = json.dumps({"utterances": [{"speaker": "A", "text": "Hi", "start": 0, "end": 1}]})
+        segments = parse_transcript(data, "json")
+        assert len(segments) == 1
+
+    def test_unknown_format_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown transcript format"):
+            parse_transcript("data", "unknown_format")


### PR DESCRIPTION
## Summary
- **Parsers**: VTT (regex-based, multi-line cues), plain text (speaker label extraction), JSON (AssemblyAI + MeetingBank formats)
- **Chunking**: Naive (fixed-size with overlap, configurable token count) and speaker-turn (groups consecutive same-speaker segments, splits long turns)
- **Embedding**: OpenAI text-embedding-3-small integration with batch support
- **Storage**: Supabase helpers for meetings and chunks (batched insert of 50)
- **Pipeline**: End-to-end `ingest_transcript()` — parse, chunk, embed, store
- **22 tests** covering all parsers and both chunking strategies
- **Test fixture**: sample.vtt with 8-segment council meeting transcript

## Files
- `src/ingestion/models.py` — TranscriptSegment + Chunk dataclasses
- `src/ingestion/parsers.py` — 3 parsers + dispatcher
- `src/ingestion/chunking.py` — naive_chunk + speaker_turn_chunk
- `src/ingestion/embeddings.py` — OpenAI embedding wrapper
- `src/ingestion/storage.py` — Supabase client + store functions
- `src/ingestion/pipeline.py` — end-to-end orchestrator
- `tests/test_ingestion.py` — 22 tests
- `tests/fixtures/sample.vtt` — test data

## Test plan
- [x] `pytest tests/test_ingestion.py -v` — 22/22 passed
- [x] `ruff check` — clean
- [x] `ruff format --check` — formatted
- [ ] Integration: embed + store requires API keys (tested manually or in Issue #3)

Closes #2