### PR TITLE
feat: query pipeline + FastAPI endpoints (#3)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,10 +1,18 @@
 from fastapi import FastAPI
 
+from src.api.routes.ingest import router as ingest_router
+from src.api.routes.meetings import router as meetings_router
+from src.api.routes.query import router as query_router
+
 app = FastAPI(
     title="Meeting Intelligence API",
     description="RAG-powered meeting transcript analysis",
     version="0.1.0",
 )
+
+app.include_router(ingest_router)
+app.include_router(query_router)
+app.include_router(meetings_router)
 
 
 @app.get("/health")

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -1,0 +1,70 @@
+"""Pydantic request/response schemas for the Meeting Intelligence API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class QueryRequest(BaseModel):
+    """Request body for the /api/query endpoint."""
+
+    question: str
+    meeting_id: str | None = None
+    strategy: str = "hybrid"  # "semantic" or "hybrid"
+
+
+class SourceChunk(BaseModel):
+    """A single retrieved transcript chunk with metadata."""
+
+    content: str
+    speaker: str | None = None
+    start_time: float | None = None
+    end_time: float | None = None
+    similarity: float | None = None
+    meeting_id: str | None = None
+    combined_score: float | None = None
+
+
+class QueryResponse(BaseModel):
+    """Response body for the /api/query endpoint."""
+
+    answer: str
+    sources: list[SourceChunk]
+    model: str | None = None
+    usage: dict | None = None
+
+
+class MeetingSummary(BaseModel):
+    """Summary representation of a meeting for list views."""
+
+    id: str
+    title: str
+    source_file: str | None = None
+    transcript_format: str | None = None
+    num_speakers: int | None = None
+    created_at: str | None = None
+    chunk_count: int = 0
+
+
+class MeetingDetail(BaseModel):
+    """Full meeting detail including chunks and extracted items."""
+
+    id: str
+    title: str
+    source_file: str | None = None
+    transcript_format: str | None = None
+    num_speakers: int | None = None
+    created_at: str | None = None
+    raw_transcript: str | None = None
+    summary: str | None = None
+    chunks: list[SourceChunk] = []
+    extracted_items: list[dict] = []
+
+
+class IngestResponse(BaseModel):
+    """Response body for the /api/ingest endpoint."""
+
+    meeting_id: str
+    title: str
+    num_chunks: int
+    chunking_strategy: str

--- a/src/api/routes/ingest.py
+++ b/src/api/routes/ingest.py
@@ -1,0 +1,43 @@
+"""Ingest endpoint: upload and process meeting transcripts."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, File, Form, UploadFile
+
+from src.api.models import IngestResponse
+from src.ingestion.pipeline import ingest_transcript
+from src.ingestion.storage import get_supabase_client
+
+router = APIRouter()
+
+
+@router.post("/api/ingest", response_model=IngestResponse)
+async def ingest(
+    file: Annotated[UploadFile, File(...)],
+    title: Annotated[str, Form()] = "Untitled Meeting",
+    chunking_strategy: Annotated[str, Form()] = "speaker_turn",
+) -> IngestResponse:
+    """Upload a transcript file and run the ingestion pipeline."""
+    content = (await file.read()).decode("utf-8")
+
+    # Determine format from file extension
+    ext = file.filename.rsplit(".", 1)[-1].lower() if file.filename else "txt"
+    format_map = {"vtt": "vtt", "txt": "text", "json": "json"}
+    transcript_format = format_map.get(ext, "text")
+
+    meeting_id = ingest_transcript(content, transcript_format, title, chunking_strategy)
+
+    # Get chunk count
+    client = get_supabase_client()
+    chunks = (
+        client.table("chunks").select("id", count="exact").eq("meeting_id", meeting_id).execute()
+    )
+
+    return IngestResponse(
+        meeting_id=meeting_id,
+        title=title,
+        num_chunks=chunks.count or 0,
+        chunking_strategy=chunking_strategy,
+    )

--- a/src/api/routes/meetings.py
+++ b/src/api/routes/meetings.py
@@ -1,0 +1,83 @@
+"""Meeting endpoints: list and detail views."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from src.api.models import MeetingDetail, MeetingSummary, SourceChunk
+from src.ingestion.storage import get_supabase_client
+
+router = APIRouter()
+
+
+@router.get("/api/meetings", response_model=list[MeetingSummary])
+async def list_meetings() -> list[MeetingSummary]:
+    """List all meetings ordered by creation date (newest first)."""
+    client = get_supabase_client()
+    result = client.table("meetings").select("*").order("created_at", desc=True).execute()
+
+    meetings: list[MeetingSummary] = []
+    for m in result.data:
+        # Get chunk count
+        chunks = (
+            client.table("chunks").select("id", count="exact").eq("meeting_id", m["id"]).execute()
+        )
+        meetings.append(
+            MeetingSummary(
+                id=m["id"],
+                title=m["title"],
+                source_file=m.get("source_file"),
+                transcript_format=m.get("transcript_format"),
+                num_speakers=m.get("num_speakers"),
+                created_at=m.get("created_at"),
+                chunk_count=chunks.count or 0,
+            )
+        )
+    return meetings
+
+
+@router.get("/api/meetings/{meeting_id}", response_model=MeetingDetail)
+async def get_meeting(meeting_id: str) -> MeetingDetail:
+    """Get full meeting details including chunks and extracted items."""
+    client = get_supabase_client()
+    result = client.table("meetings").select("*").eq("id", meeting_id).execute()
+
+    if not result.data:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+
+    m = result.data[0]
+
+    # Get chunks
+    chunks_result = (
+        client.table("chunks")
+        .select("*")
+        .eq("meeting_id", meeting_id)
+        .order("chunk_index")
+        .execute()
+    )
+
+    # Get extracted items
+    items_result = (
+        client.table("extracted_items").select("*").eq("meeting_id", meeting_id).execute()
+    )
+
+    return MeetingDetail(
+        id=m["id"],
+        title=m["title"],
+        source_file=m.get("source_file"),
+        transcript_format=m.get("transcript_format"),
+        num_speakers=m.get("num_speakers"),
+        created_at=m.get("created_at"),
+        raw_transcript=m.get("raw_transcript"),
+        summary=m.get("summary"),
+        chunks=[
+            SourceChunk(
+                content=c["content"],
+                speaker=c.get("speaker"),
+                start_time=c.get("start_time"),
+                end_time=c.get("end_time"),
+            )
+            for c in chunks_result.data
+        ],
+        extracted_items=items_result.data,
+    )

--- a/src/api/routes/query.py
+++ b/src/api/routes/query.py
@@ -1,0 +1,40 @@
+"""Query endpoint: retrieve context and generate answers."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from src.api.models import QueryRequest, QueryResponse
+from src.retrieval.generation import generate_answer
+from src.retrieval.search import hybrid_search, semantic_search
+
+router = APIRouter()
+
+
+@router.post("/api/query", response_model=QueryResponse)
+async def query(request: QueryRequest) -> QueryResponse:
+    """Answer a question using RAG over meeting transcripts."""
+    # Retrieve relevant chunks
+    if request.strategy == "semantic":
+        chunks = semantic_search(
+            request.question,
+            meeting_id=request.meeting_id,
+        )
+    else:
+        chunks = hybrid_search(request.question)
+
+    if not chunks:
+        return QueryResponse(
+            answer="No relevant meeting content found for your question.",
+            sources=[],
+        )
+
+    # Generate answer with Claude
+    result = generate_answer(request.question, chunks)
+
+    return QueryResponse(
+        answer=result["answer"],
+        sources=result["sources"],
+        model=result.get("model"),
+        usage=result.get("usage"),
+    )

--- a/src/retrieval/generation.py
+++ b/src/retrieval/generation.py
@@ -1,0 +1,60 @@
+"""Claude-powered answer generation with source attribution."""
+
+from __future__ import annotations
+
+from anthropic import Anthropic
+
+
+def generate_answer(question: str, context_chunks: list[dict]) -> dict:
+    """Generate an answer using Claude with source attribution.
+
+    Args:
+        question: The user's question.
+        context_chunks: Retrieved transcript chunks with metadata.
+
+    Returns:
+        Dictionary with answer, sources, model, and usage info.
+    """
+    # Format context
+    context_parts: list[str] = []
+    for i, chunk in enumerate(context_chunks):
+        speaker = chunk.get("speaker", "Unknown")
+        time = chunk.get("start_time")
+        time_str = f" [{time:.1f}s]" if time else ""
+        context_parts.append(f"[Source {i + 1}] {speaker}{time_str}: {chunk['content']}")
+
+    context = "\n\n".join(context_parts)
+
+    client = Anthropic()  # reads ANTHROPIC_API_KEY from env
+    response = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=1024,
+        system=(
+            "You are a meeting intelligence assistant. Answer questions based "
+            "on the provided meeting transcript excerpts.\n\n"
+            "Rules:\n"
+            "- Only answer based on the provided context. If the answer isn't "
+            "in the context, say so.\n"
+            "- Cite your sources using [Source N] notation.\n"
+            "- Include speaker names when relevant.\n"
+            "- Be concise and direct."
+        ),
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    f"Context from meeting transcripts:\n\n{context}\n\nQuestion: {question}"
+                ),
+            }
+        ],
+    )
+
+    return {
+        "answer": response.content[0].text,
+        "sources": context_chunks,
+        "model": response.model,
+        "usage": {
+            "input_tokens": response.usage.input_tokens,
+            "output_tokens": response.usage.output_tokens,
+        },
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,39 @@
+"""Tests for API endpoints (no external API keys required)."""
+
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+
+client = TestClient(app)
+client_no_raise = TestClient(app, raise_server_exceptions=False)
+
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+
+
+def test_query_validation():
+    """Test that query endpoint validates input."""
+    response = client.post("/api/query", json={})
+    assert response.status_code == 422  # missing required field
+
+
+def test_query_requires_question():
+    """Empty string is a valid str, so validation passes."""
+    response = client_no_raise.post("/api/query", json={"question": ""})
+    # Should still accept (empty string is valid str)
+    # The actual search will fail without Supabase/OpenAI, but validation passes
+    assert response.status_code in [200, 500]  # 500 if no Supabase
+
+
+def test_meetings_list():
+    """Without Supabase, this will fail gracefully."""
+    response = client_no_raise.get("/api/meetings")
+    assert response.status_code in [200, 500]
+
+
+def test_ingest_requires_file():
+    """Ingest requires a file upload."""
+    response = client.post("/api/ingest")
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Semantic search via Supabase `match_chunks()` RPC and hybrid search via `hybrid_search()` RPC
- Claude-powered answer generation with source attribution (claude-sonnet-4-20250514)
- FastAPI endpoints: POST /api/ingest, POST /api/query, GET /api/meetings, GET /api/meetings/{id}
- Pydantic request/response models for all endpoints
- 6 tests passing (5 API + 1 health)

## Test plan
- [x] `pytest tests/test_api.py` — all 5 API tests pass
- [x] `pytest tests/test_health.py` — health endpoint test passes

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)