### PR TITLE
feat: evaluation framework — metrics, cross-check, strategy comparison (#7)

### DIFF
--- a/src/evaluation/compare_strategies.py
+++ b/src/evaluation/compare_strategies.py
@@ -1,0 +1,172 @@
+"""Strategy comparison: evaluate across chunking + retrieval combinations.
+
+Runs the evaluation pipeline across all strategy combinations:
+- Chunking: naive, speaker_turn
+- Retrieval: semantic, hybrid
+
+Generates a comparison table with per-strategy metrics.
+"""
+
+from __future__ import annotations
+
+from src.evaluation.metrics import evaluate_all_metrics
+from src.evaluation.models import EvaluationResult, StrategyResult, TestQuestion
+from src.retrieval.generation import generate_answer
+from src.retrieval.search import hybrid_search, semantic_search
+
+# All strategy combinations to evaluate
+STRATEGY_COMBINATIONS: list[tuple[str, str]] = [
+    ("naive", "semantic"),
+    ("naive", "hybrid"),
+    ("speaker_turn", "semantic"),
+    ("speaker_turn", "hybrid"),
+]
+
+
+def _retrieve_and_generate(
+    question: str,
+    retrieval_strategy: str,
+    chunking_strategy: str | None = None,
+    meeting_id: str | None = None,
+) -> tuple[str, list[str]]:
+    """Retrieve context and generate answer for a given strategy combination.
+
+    Args:
+        question: The question to answer.
+        retrieval_strategy: "semantic" or "hybrid".
+        chunking_strategy: Filter chunks by chunking strategy (if supported).
+        meeting_id: Optional meeting ID filter.
+
+    Returns:
+        Tuple of (generated_answer, list_of_context_strings).
+    """
+    if retrieval_strategy == "semantic":
+        chunks = semantic_search(
+            question,
+            meeting_id=meeting_id,
+            strategy=chunking_strategy,
+        )
+    else:
+        # hybrid_search doesn't support strategy filter yet
+        chunks = hybrid_search(question)
+
+    if not chunks:
+        return "No relevant meeting content found.", []
+
+    result = generate_answer(question, chunks)
+    contexts = [c.get("content", "") for c in chunks]
+    return result["answer"], contexts
+
+
+def evaluate_strategy(
+    questions: list[TestQuestion],
+    chunking_strategy: str,
+    retrieval_strategy: str,
+) -> StrategyResult:
+    """Evaluate a single strategy combination across all questions.
+
+    Args:
+        questions: List of test questions.
+        chunking_strategy: "naive" or "speaker_turn".
+        retrieval_strategy: "semantic" or "hybrid".
+
+    Returns:
+        StrategyResult with aggregated metrics.
+    """
+    individual_results: list[EvaluationResult] = []
+
+    for q in questions:
+        answer, contexts = _retrieve_and_generate(
+            q.question,
+            retrieval_strategy,
+            chunking_strategy=chunking_strategy,
+            meeting_id=q.source_meeting_id if q.source_meeting_id != "multi" else None,
+        )
+
+        metrics = evaluate_all_metrics(
+            question=q.question,
+            expected_answer=q.expected_answer,
+            generated_answer=answer,
+            contexts=contexts,
+        )
+
+        individual_results.append(
+            EvaluationResult(
+                question=q,
+                generated_answer=answer,
+                retrieved_contexts=contexts,
+                metrics=metrics,
+            )
+        )
+
+    # Aggregate metrics
+    n = len(individual_results)
+    if n == 0:
+        return StrategyResult(
+            chunking_strategy=chunking_strategy,
+            retrieval_strategy=retrieval_strategy,
+        )
+
+    avg_faith = sum(r.metrics["faithfulness"].score for r in individual_results) / n
+    avg_relev = sum(r.metrics["answer_relevancy"].score for r in individual_results) / n
+    avg_prec = sum(r.metrics["context_precision"].score for r in individual_results) / n
+    avg_recall = sum(r.metrics["context_recall"].score for r in individual_results) / n
+
+    return StrategyResult(
+        chunking_strategy=chunking_strategy,
+        retrieval_strategy=retrieval_strategy,
+        avg_faithfulness=round(avg_faith, 3),
+        avg_relevancy=round(avg_relev, 3),
+        avg_context_precision=round(avg_prec, 3),
+        avg_context_recall=round(avg_recall, 3),
+        num_questions=n,
+        individual_results=individual_results,
+    )
+
+
+def compare_all_strategies(
+    questions: list[TestQuestion],
+    strategies: list[tuple[str, str]] | None = None,
+) -> list[StrategyResult]:
+    """Run evaluation across all strategy combinations.
+
+    Args:
+        questions: List of test questions.
+        strategies: Optional list of (chunking, retrieval) tuples. Defaults
+            to STRATEGY_COMBINATIONS.
+
+    Returns:
+        List of StrategyResult objects, one per strategy combination.
+    """
+    combos = strategies or STRATEGY_COMBINATIONS
+    results: list[StrategyResult] = []
+    for chunking, retrieval in combos:
+        result = evaluate_strategy(questions, chunking, retrieval)
+        results.append(result)
+    return results
+
+
+def format_comparison_table(results: list[StrategyResult]) -> str:
+    """Format strategy comparison results as a markdown table.
+
+    Args:
+        results: List of StrategyResult objects.
+
+    Returns:
+        Markdown-formatted comparison table string.
+    """
+    header = (
+        "| Chunking | Retrieval | Faithfulness | Relevancy | "
+        "Context Precision | Context Recall | N |\n"
+        "|----------|-----------|-------------|-----------|"
+        "-------------------|----------------|---|\n"
+    )
+    rows: list[str] = []
+    for r in results:
+        rows.append(
+            f"| {r.chunking_strategy} | {r.retrieval_strategy} | "
+            f"{r.avg_faithfulness:.3f} | {r.avg_relevancy:.3f} | "
+            f"{r.avg_context_precision:.3f} | {r.avg_context_recall:.3f} | "
+            f"{r.num_questions} |"
+        )
+    return header + "\n".join(rows)

--- a/src/evaluation/cross_check.py
+++ b/src/evaluation/cross_check.py
@@ -1,0 +1,264 @@
+"""Cross-check evaluation: RAG vs context-stuffing comparison.
+
+For each test question, generates answers via both the RAG pipeline
+(retrieve + generate) and context-stuffing (full transcript + generate),
+then uses Claude as judge to compare.
+"""
+
+from __future__ import annotations
+
+import json
+
+from anthropic import Anthropic
+
+from src.config import settings
+from src.evaluation.models import (
+    CrossCheckResult,
+    CrossCheckVerdict,
+    TestQuestion,
+)
+from src.retrieval.generation import generate_answer
+from src.retrieval.search import hybrid_search, semantic_search
+
+JUDGE_PROMPT = """\
+You are comparing two answers to the same question about a meeting transcript.
+
+QUESTION:
+{question}
+
+EXPECTED ANSWER:
+{expected_answer}
+
+ANSWER A (RAG — retrieved relevant excerpts):
+{rag_answer}
+
+ANSWER B (Context Stuffing — full transcript):
+{context_stuffing_answer}
+
+Compare both answers against the expected answer. Consider:
+1. Correctness: Which answer is more factually correct?
+2. Completeness: Which answer covers more of the expected information?
+3. Conciseness: Which answer avoids irrelevant information?
+
+Return a JSON object with exactly:
+- "verdict": one of "RAG_BETTER", "CONTEXT_STUFFING_BETTER", or "EQUIVALENT"
+- "rag_score": float 0.0-1.0 rating Answer A quality
+- "context_stuffing_score": float 0.0-1.0 rating Answer B quality
+- "reasoning": brief explanation of your judgment
+
+Return ONLY the JSON object.
+"""
+
+
+def _generate_context_stuffing_answer(
+    question: str, transcript: str, max_chars: int = 80000
+) -> str:
+    """Generate an answer by stuffing the full transcript into context.
+
+    Args:
+        question: The question to answer.
+        transcript: Full meeting transcript text.
+        max_chars: Maximum transcript characters (to stay within token limits).
+
+    Returns:
+        The generated answer text.
+    """
+    truncated = transcript[:max_chars]
+    client = Anthropic(api_key=settings.anthropic_api_key)
+    response = client.messages.create(
+        model=settings.llm_model,
+        max_tokens=1024,
+        system=(
+            "You are a meeting intelligence assistant. Answer questions based "
+            "on the provided meeting transcript.\n\n"
+            "Rules:\n"
+            "- Only answer based on the provided transcript.\n"
+            "- Be concise and direct.\n"
+            "- If the answer isn't in the transcript, say so."
+        ),
+        messages=[
+            {
+                "role": "user",
+                "content": f"Full meeting transcript:\n\n{truncated}\n\nQuestion: {question}",
+            }
+        ],
+    )
+    return response.content[0].text
+
+
+def _generate_rag_answer(
+    question: str,
+    retrieval_strategy: str = "hybrid",
+    meeting_id: str | None = None,
+) -> tuple[str, list[dict]]:
+    """Generate an answer using the RAG pipeline.
+
+    Args:
+        question: The question to answer.
+        retrieval_strategy: "semantic" or "hybrid".
+        meeting_id: Optional meeting ID filter.
+
+    Returns:
+        Tuple of (answer_text, retrieved_chunks).
+    """
+    if retrieval_strategy == "semantic":
+        chunks = semantic_search(question, meeting_id=meeting_id)
+    else:
+        chunks = hybrid_search(question)
+
+    if not chunks:
+        return "No relevant meeting content found.", []
+
+    result = generate_answer(question, chunks)
+    return result["answer"], chunks
+
+
+def _judge_answers(
+    question: str,
+    expected_answer: str,
+    rag_answer: str,
+    context_stuffing_answer: str,
+) -> dict:
+    """Use Claude to judge which answer is better."""
+    prompt = JUDGE_PROMPT.format(
+        question=question,
+        expected_answer=expected_answer,
+        rag_answer=rag_answer,
+        context_stuffing_answer=context_stuffing_answer,
+    )
+    client = Anthropic(api_key=settings.anthropic_api_key)
+    response = client.messages.create(
+        model=settings.llm_model,
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = response.content[0].text.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        lines = [ln for ln in lines if not ln.strip().startswith("```")]
+        text = "\n".join(lines)
+    return json.loads(text)
+
+
+def cross_check_question(
+    test_question: TestQuestion,
+    transcript: str,
+    retrieval_strategy: str = "hybrid",
+) -> CrossCheckResult:
+    """Run cross-check evaluation for a single question.
+
+    Args:
+        test_question: The test question with expected answer.
+        transcript: Full meeting transcript for context-stuffing.
+        retrieval_strategy: "semantic" or "hybrid" for RAG pipeline.
+
+    Returns:
+        CrossCheckResult with verdict and scores.
+    """
+    # Generate RAG answer
+    rag_answer, _ = _generate_rag_answer(
+        test_question.question,
+        retrieval_strategy=retrieval_strategy,
+        meeting_id=test_question.source_meeting_id,
+    )
+
+    # Generate context-stuffing answer
+    cs_answer = _generate_context_stuffing_answer(
+        test_question.question, transcript
+    )
+
+    # Judge
+    try:
+        judgment = _judge_answers(
+            test_question.question,
+            test_question.expected_answer,
+            rag_answer,
+            cs_answer,
+        )
+        verdict = CrossCheckVerdict(judgment["verdict"])
+        return CrossCheckResult(
+            question=test_question,
+            rag_answer=rag_answer,
+            context_stuffing_answer=cs_answer,
+            verdict=verdict,
+            reasoning=judgment.get("reasoning", ""),
+            rag_score=float(judgment.get("rag_score", 0.0)),
+            context_stuffing_score=float(
+                judgment.get("context_stuffing_score", 0.0)
+            ),
+        )
+    except (json.JSONDecodeError, KeyError, ValueError):
+        return CrossCheckResult(
+            question=test_question,
+            rag_answer=rag_answer,
+            context_stuffing_answer=cs_answer,
+            verdict=CrossCheckVerdict.EQUIVALENT,
+            reasoning="Failed to parse judge response; defaulting to EQUIVALENT.",
+        )
+
+
+def run_cross_check(
+    questions: list[TestQuestion],
+    transcripts: dict[str, str],
+    retrieval_strategy: str = "hybrid",
+) -> list[CrossCheckResult]:
+    """Run cross-check evaluation across all questions.
+
+    Args:
+        questions: List of test questions.
+        transcripts: Mapping of meeting_id -> transcript text.
+        retrieval_strategy: "semantic" or "hybrid".
+
+    Returns:
+        List of CrossCheckResult objects.
+    """
+    results: list[CrossCheckResult] = []
+    for q in questions:
+        transcript = transcripts.get(q.source_meeting_id, "")
+        if not transcript and q.source_meeting_id == "multi":
+            # For multi-meeting questions, concatenate all transcripts
+            transcript = "\n\n---\n\n".join(transcripts.values())
+        if not transcript:
+            continue
+        result = cross_check_question(q, transcript, retrieval_strategy)
+        results.append(result)
+    return results
+
+
+def summarize_cross_check(results: list[CrossCheckResult]) -> dict:
+    """Summarize cross-check results into aggregate statistics.
+
+    Returns:
+        Dictionary with counts, percentages, and per-category breakdowns.
+    """
+    if not results:
+        return {"total": 0}
+
+    total = len(results)
+    counts = {v: 0 for v in CrossCheckVerdict}
+    for r in results:
+        counts[r.verdict] += 1
+
+    # Per-category breakdown
+    by_category: dict[str, dict[str, int]] = {}
+    for r in results:
+        cat = r.question.category.value
+        if cat not in by_category:
+            by_category[cat] = {v.value: 0 for v in CrossCheckVerdict}
+        by_category[cat][r.verdict.value] += 1
+
+    avg_rag = sum(r.rag_score for r in results) / total
+    avg_cs = sum(r.context_stuffing_score for r in results) / total
+
+    return {
+        "total": total,
+        "rag_better": counts[CrossCheckVerdict.RAG_BETTER],
+        "context_stuffing_better": counts[CrossCheckVerdict.CONTEXT_STUFFING_BETTER],
+        "equivalent": counts[CrossCheckVerdict.EQUIVALENT],
+        "rag_better_pct": counts[CrossCheckVerdict.RAG_BETTER] / total * 100,
+        "context_stuffing_better_pct": counts[CrossCheckVerdict.CONTEXT_STUFFING_BETTER] / total * 100,
+        "equivalent_pct": counts[CrossCheckVerdict.EQUIVALENT] / total * 100,
+        "avg_rag_score": round(avg_rag, 3),
+        "avg_context_stuffing_score": round(avg_cs, 3),
+        "by_category": by_category,
+    }

--- a/src/evaluation/generate_test_set.py
+++ b/src/evaluation/generate_test_set.py
@@ -1,0 +1,257 @@
+"""Generate evaluation test sets from meeting transcripts using Claude."""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from anthropic import Anthropic
+
+from src.config import settings
+from src.evaluation.models import Difficulty, QuestionCategory, TestQuestion
+
+# How many questions to request per category per meeting
+QUESTIONS_PER_CATEGORY: dict[QuestionCategory, int] = {
+    QuestionCategory.FACTUAL: 8,
+    QuestionCategory.INFERENCE: 5,
+    QuestionCategory.ACTION_ITEMS: 4,
+    QuestionCategory.DECISIONS: 4,
+}
+
+# Difficulty distribution ratios (easy, medium, hard)
+DIFFICULTY_RATIOS: dict[Difficulty, float] = {
+    Difficulty.EASY: 0.4,
+    Difficulty.MEDIUM: 0.4,
+    Difficulty.HARD: 0.2,
+}
+
+GENERATION_PROMPT = """\
+You are generating evaluation questions for a meeting intelligence RAG system.
+
+Given the meeting transcript below, generate exactly {num_questions} questions \
+of category "{category}" with difficulty "{difficulty}".
+
+Category definitions:
+- factual: Questions with explicit answers stated directly in the transcript.
+- inference: Questions requiring reasoning across multiple parts of the transcript.
+- action_items: Questions about tasks assigned, deadlines, or follow-ups mentioned.
+- decisions: Questions about decisions made or conclusions reached in the meeting.
+
+Difficulty definitions:
+- easy: Answer is in a single, obvious location in the transcript.
+- medium: Answer requires combining 2-3 pieces of information.
+- hard: Answer requires deep understanding, synthesis, or reasoning about implicit information.
+
+Return a JSON array of objects with exactly these fields:
+- "question": the question text
+- "expected_answer": a concise, correct answer based on the transcript
+
+TRANSCRIPT:
+{transcript}
+
+Return ONLY the JSON array, no other text.
+"""
+
+MULTI_MEETING_PROMPT = """\
+You are generating evaluation questions that span multiple meetings.
+
+Given excerpts from {num_meetings} different meetings below, generate exactly \
+{num_questions} questions that require information from at least 2 meetings to answer.
+
+These should be "hard" difficulty questions about cross-meeting themes, contradictions, \
+evolving decisions, or recurring topics.
+
+Return a JSON array of objects with exactly these fields:
+- "question": the question text
+- "expected_answer": a concise, correct answer referencing relevant meetings
+
+MEETING EXCERPTS:
+{transcripts}
+
+Return ONLY the JSON array, no other text.
+"""
+
+
+def _call_claude(prompt: str) -> str:
+    """Make a Claude API call and return the text response."""
+    client = Anthropic(api_key=settings.anthropic_api_key)
+    response = client.messages.create(
+        model=settings.llm_model,
+        max_tokens=4096,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.content[0].text
+
+
+def _parse_questions_json(raw: str) -> list[dict]:
+    """Parse Claude's response as a JSON array, handling markdown fences."""
+    text = raw.strip()
+    # Strip markdown code fences if present
+    if text.startswith("```"):
+        lines = text.split("\n")
+        # Remove first and last lines (the fences)
+        lines = [ln for ln in lines if not ln.strip().startswith("```")]
+        text = "\n".join(lines)
+    return json.loads(text)
+
+
+def generate_single_meeting_questions(
+    transcript: str,
+    meeting_id: str,
+    max_transcript_chars: int = 30000,
+) -> list[TestQuestion]:
+    """Generate test questions from a single meeting transcript.
+
+    Args:
+        transcript: The full meeting transcript text.
+        meeting_id: ID of the source meeting.
+        max_transcript_chars: Truncate transcript to this length to stay within
+            token limits.
+
+    Returns:
+        List of TestQuestion objects.
+    """
+    truncated = transcript[:max_transcript_chars]
+    questions: list[TestQuestion] = []
+
+    for category, count in QUESTIONS_PER_CATEGORY.items():
+        for difficulty, ratio in DIFFICULTY_RATIOS.items():
+            num = max(1, int(count * ratio))
+            prompt = GENERATION_PROMPT.format(
+                num_questions=num,
+                category=category.value,
+                difficulty=difficulty.value,
+                transcript=truncated,
+            )
+            try:
+                raw = _call_claude(prompt)
+                parsed = _parse_questions_json(raw)
+                for item in parsed:
+                    questions.append(
+                        TestQuestion(
+                            question=item["question"],
+                            expected_answer=item["expected_answer"],
+                            category=category,
+                            difficulty=difficulty,
+                            source_meeting_id=meeting_id,
+                            question_id=str(uuid.uuid4()),
+                        )
+                    )
+            except (json.JSONDecodeError, KeyError, IndexError):
+                # Skip malformed responses — best-effort generation
+                continue
+
+    return questions
+
+
+def generate_multi_meeting_questions(
+    transcripts: dict[str, str],
+    num_questions: int = 10,
+    excerpt_chars: int = 5000,
+) -> list[TestQuestion]:
+    """Generate questions that span multiple meetings.
+
+    Args:
+        transcripts: Mapping of meeting_id -> transcript text.
+        num_questions: How many multi-meeting questions to generate.
+        excerpt_chars: Characters per meeting excerpt.
+
+    Returns:
+        List of TestQuestion objects with category MULTI_MEETING.
+    """
+    excerpts = "\n\n---\n\n".join(
+        f"[Meeting {mid}]:\n{text[:excerpt_chars]}" for mid, text in transcripts.items()
+    )
+
+    prompt = MULTI_MEETING_PROMPT.format(
+        num_meetings=len(transcripts),
+        num_questions=num_questions,
+        transcripts=excerpts,
+    )
+
+    questions: list[TestQuestion] = []
+    try:
+        raw = _call_claude(prompt)
+        parsed = _parse_questions_json(raw)
+        for item in parsed:
+            questions.append(
+                TestQuestion(
+                    question=item["question"],
+                    expected_answer=item["expected_answer"],
+                    category=QuestionCategory.MULTI_MEETING,
+                    difficulty=Difficulty.HARD,
+                    source_meeting_id="multi",
+                    question_id=str(uuid.uuid4()),
+                )
+            )
+    except (json.JSONDecodeError, KeyError, IndexError):
+        pass
+
+    return questions
+
+
+def generate_test_set(
+    transcripts: dict[str, str],
+    target_min: int = 150,
+    target_max: int = 250,
+) -> list[TestQuestion]:
+    """Generate a complete test set from multiple meeting transcripts.
+
+    Args:
+        transcripts: Mapping of meeting_id -> transcript text.
+        target_min: Minimum number of questions to aim for.
+        target_max: Maximum number of questions.
+
+    Returns:
+        List of TestQuestion objects.
+    """
+    all_questions: list[TestQuestion] = []
+
+    # Generate per-meeting questions
+    for meeting_id, transcript in transcripts.items():
+        qs = generate_single_meeting_questions(transcript, meeting_id)
+        all_questions.extend(qs)
+        if len(all_questions) >= target_max:
+            break
+
+    # Generate multi-meeting questions if we have multiple meetings
+    if len(transcripts) >= 2:
+        multi_qs = generate_multi_meeting_questions(transcripts)
+        all_questions.extend(multi_qs)
+
+    # Trim to target_max if needed
+    return all_questions[:target_max]
+
+
+def save_test_set(questions: list[TestQuestion], path: str) -> None:
+    """Save test set to a JSON file."""
+    data = [
+        {
+            "question_id": q.question_id,
+            "question": q.question,
+            "expected_answer": q.expected_answer,
+            "category": q.category.value,
+            "difficulty": q.difficulty.value,
+            "source_meeting_id": q.source_meeting_id,
+        }
+        for q in questions
+    ]
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def load_test_set(path: str) -> list[TestQuestion]:
+    """Load a test set from a JSON file."""
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    return [
+        TestQuestion(
+            question_id=item.get("question_id", str(uuid.uuid4())),
+            question=item["question"],
+            expected_answer=item["expected_answer"],
+            category=QuestionCategory(item["category"]),
+            difficulty=Difficulty(item["difficulty"]),
+            source_meeting_id=item["source_meeting_id"],
+        )
+        for item in data
+    ]

--- a/src/evaluation/metrics.py
+++ b/src/evaluation/metrics.py
@@ -1,0 +1,267 @@
+"""RAGAS-style evaluation metrics using Claude as judge.
+
+Each metric returns a 0-1 score with reasoning. Metrics implemented:
+- Faithfulness: Is the answer grounded in the retrieved context?
+- Answer Relevancy: Does the answer address the question?
+- Context Precision: Are the retrieved contexts relevant to the question?
+- Context Recall: Does the context contain the information needed for the expected answer?
+"""
+
+from __future__ import annotations
+
+import json
+
+from anthropic import Anthropic
+
+from src.config import settings
+from src.evaluation.models import MetricResult
+
+FAITHFULNESS_PROMPT = """\
+You are evaluating the faithfulness of a generated answer. Faithfulness measures \
+whether every claim in the answer is supported by the provided context.
+
+CONTEXT:
+{context}
+
+ANSWER:
+{answer}
+
+Score the faithfulness from 0.0 to 1.0:
+- 1.0: Every claim in the answer is directly supported by the context.
+- 0.5: Some claims are supported, others are not verifiable from context.
+- 0.0: The answer contains claims that contradict or are unsupported by the context.
+
+Return a JSON object with exactly:
+- "score": a float between 0.0 and 1.0
+- "reasoning": a brief explanation
+
+Return ONLY the JSON object.
+"""
+
+ANSWER_RELEVANCY_PROMPT = """\
+You are evaluating how relevant an answer is to the asked question.
+
+QUESTION:
+{question}
+
+ANSWER:
+{answer}
+
+Score the answer relevancy from 0.0 to 1.0:
+- 1.0: The answer directly and completely addresses the question.
+- 0.5: The answer partially addresses the question or includes unnecessary information.
+- 0.0: The answer does not address the question at all.
+
+Return a JSON object with exactly:
+- "score": a float between 0.0 and 1.0
+- "reasoning": a brief explanation
+
+Return ONLY the JSON object.
+"""
+
+CONTEXT_PRECISION_PROMPT = """\
+You are evaluating context precision. This measures whether the retrieved \
+context chunks are relevant to answering the question.
+
+QUESTION:
+{question}
+
+RETRIEVED CONTEXT CHUNKS:
+{context}
+
+For each chunk, determine if it is relevant to answering the question. \
+Context precision is the fraction of retrieved chunks that are relevant.
+
+Score from 0.0 to 1.0:
+- 1.0: All retrieved chunks are relevant.
+- 0.5: About half are relevant.
+- 0.0: None of the chunks are relevant.
+
+Return a JSON object with exactly:
+- "score": a float between 0.0 and 1.0
+- "reasoning": a brief explanation
+
+Return ONLY the JSON object.
+"""
+
+CONTEXT_RECALL_PROMPT = """\
+You are evaluating context recall. This measures whether the retrieved context \
+contains the information needed to produce the expected answer.
+
+EXPECTED ANSWER:
+{expected_answer}
+
+RETRIEVED CONTEXT:
+{context}
+
+Determine what fraction of the claims in the expected answer can be found in \
+or inferred from the retrieved context.
+
+Score from 0.0 to 1.0:
+- 1.0: All information needed for the expected answer is present in the context.
+- 0.5: About half the needed information is present.
+- 0.0: The context contains none of the needed information.
+
+Return a JSON object with exactly:
+- "score": a float between 0.0 and 1.0
+- "reasoning": a brief explanation
+
+Return ONLY the JSON object.
+"""
+
+
+def _call_claude_judge(prompt: str) -> dict:
+    """Call Claude as a judge and parse the JSON response."""
+    client = Anthropic(api_key=settings.anthropic_api_key)
+    response = client.messages.create(
+        model=settings.llm_model,
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = response.content[0].text.strip()
+
+    # Strip markdown fences if present
+    if text.startswith("```"):
+        lines = text.split("\n")
+        lines = [ln for ln in lines if not ln.strip().startswith("```")]
+        text = "\n".join(lines)
+
+    return json.loads(text)
+
+
+def _clamp_score(score: float) -> float:
+    """Clamp a score to [0.0, 1.0]."""
+    return max(0.0, min(1.0, float(score)))
+
+
+def _format_contexts(contexts: list[str]) -> str:
+    """Format a list of context strings into numbered chunks."""
+    parts = [f"[Chunk {i + 1}]: {ctx}" for i, ctx in enumerate(contexts)]
+    return "\n\n".join(parts)
+
+
+def score_faithfulness(answer: str, contexts: list[str]) -> MetricResult:
+    """Score how faithful the answer is to the retrieved contexts.
+
+    Args:
+        answer: The generated answer text.
+        contexts: List of retrieved context strings.
+
+    Returns:
+        MetricResult with score 0-1 and reasoning.
+    """
+    prompt = FAITHFULNESS_PROMPT.format(
+        context=_format_contexts(contexts),
+        answer=answer,
+    )
+    try:
+        result = _call_claude_judge(prompt)
+        return MetricResult(
+            score=_clamp_score(result["score"]),
+            reasoning=result.get("reasoning", ""),
+            metric_name="faithfulness",
+        )
+    except (json.JSONDecodeError, KeyError):
+        return MetricResult(score=0.0, reasoning="Failed to parse judge response", metric_name="faithfulness")
+
+
+def score_answer_relevancy(question: str, answer: str) -> MetricResult:
+    """Score how relevant the answer is to the question.
+
+    Args:
+        question: The original question.
+        answer: The generated answer text.
+
+    Returns:
+        MetricResult with score 0-1 and reasoning.
+    """
+    prompt = ANSWER_RELEVANCY_PROMPT.format(
+        question=question,
+        answer=answer,
+    )
+    try:
+        result = _call_claude_judge(prompt)
+        return MetricResult(
+            score=_clamp_score(result["score"]),
+            reasoning=result.get("reasoning", ""),
+            metric_name="answer_relevancy",
+        )
+    except (json.JSONDecodeError, KeyError):
+        return MetricResult(score=0.0, reasoning="Failed to parse judge response", metric_name="answer_relevancy")
+
+
+def score_context_precision(question: str, contexts: list[str]) -> MetricResult:
+    """Score what fraction of retrieved contexts are relevant to the question.
+
+    Args:
+        question: The original question.
+        contexts: List of retrieved context strings.
+
+    Returns:
+        MetricResult with score 0-1 and reasoning.
+    """
+    prompt = CONTEXT_PRECISION_PROMPT.format(
+        question=question,
+        context=_format_contexts(contexts),
+    )
+    try:
+        result = _call_claude_judge(prompt)
+        return MetricResult(
+            score=_clamp_score(result["score"]),
+            reasoning=result.get("reasoning", ""),
+            metric_name="context_precision",
+        )
+    except (json.JSONDecodeError, KeyError):
+        return MetricResult(score=0.0, reasoning="Failed to parse judge response", metric_name="context_precision")
+
+
+def score_context_recall(
+    expected_answer: str, contexts: list[str]
+) -> MetricResult:
+    """Score whether the context contains information needed for the expected answer.
+
+    Args:
+        expected_answer: The ground-truth expected answer.
+        contexts: List of retrieved context strings.
+
+    Returns:
+        MetricResult with score 0-1 and reasoning.
+    """
+    prompt = CONTEXT_RECALL_PROMPT.format(
+        expected_answer=expected_answer,
+        context=_format_contexts(contexts),
+    )
+    try:
+        result = _call_claude_judge(prompt)
+        return MetricResult(
+            score=_clamp_score(result["score"]),
+            reasoning=result.get("reasoning", ""),
+            metric_name="context_recall",
+        )
+    except (json.JSONDecodeError, KeyError):
+        return MetricResult(score=0.0, reasoning="Failed to parse judge response", metric_name="context_recall")
+
+
+def evaluate_all_metrics(
+    question: str,
+    expected_answer: str,
+    generated_answer: str,
+    contexts: list[str],
+) -> dict[str, MetricResult]:
+    """Run all four metrics and return results.
+
+    Args:
+        question: The original question.
+        expected_answer: The ground-truth expected answer.
+        generated_answer: The answer generated by the RAG pipeline.
+        contexts: List of retrieved context strings.
+
+    Returns:
+        Dictionary mapping metric name to MetricResult.
+    """
+    return {
+        "faithfulness": score_faithfulness(generated_answer, contexts),
+        "answer_relevancy": score_answer_relevancy(question, generated_answer),
+        "context_precision": score_context_precision(question, contexts),
+        "context_recall": score_context_recall(expected_answer, contexts),
+    }

--- a/src/evaluation/models.py
+++ b/src/evaluation/models.py
@@ -1,0 +1,90 @@
+"""Data models for the evaluation framework."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class QuestionCategory(StrEnum):
+    """Categories of test questions."""
+
+    FACTUAL = "factual"
+    INFERENCE = "inference"
+    MULTI_MEETING = "multi_meeting"
+    ACTION_ITEMS = "action_items"
+    DECISIONS = "decisions"
+
+
+class Difficulty(StrEnum):
+    """Difficulty levels for test questions."""
+
+    EASY = "easy"
+    MEDIUM = "medium"
+    HARD = "hard"
+
+
+class CrossCheckVerdict(StrEnum):
+    """Outcome of a RAG vs context-stuffing comparison."""
+
+    RAG_BETTER = "RAG_BETTER"
+    CONTEXT_STUFFING_BETTER = "CONTEXT_STUFFING_BETTER"
+    EQUIVALENT = "EQUIVALENT"
+
+
+@dataclass
+class TestQuestion:
+    """A single evaluation test question."""
+
+    question: str
+    expected_answer: str
+    category: QuestionCategory
+    difficulty: Difficulty
+    source_meeting_id: str
+    question_id: str = ""
+
+
+@dataclass
+class MetricResult:
+    """Result of a single metric evaluation."""
+
+    score: float  # 0.0 - 1.0
+    reasoning: str
+    metric_name: str
+
+
+@dataclass
+class EvaluationResult:
+    """Full evaluation result for a single question."""
+
+    question: TestQuestion
+    generated_answer: str
+    retrieved_contexts: list[str]
+    metrics: dict[str, MetricResult] = field(default_factory=dict)
+
+
+@dataclass
+class CrossCheckResult:
+    """Result of comparing RAG vs context-stuffing for one question."""
+
+    question: TestQuestion
+    rag_answer: str
+    context_stuffing_answer: str
+    verdict: CrossCheckVerdict
+    reasoning: str
+    rag_score: float = 0.0
+    context_stuffing_score: float = 0.0
+
+
+@dataclass
+class StrategyResult:
+    """Aggregated evaluation results for a strategy combination."""
+
+    chunking_strategy: str
+    retrieval_strategy: str
+    avg_faithfulness: float = 0.0
+    avg_relevancy: float = 0.0
+    avg_context_precision: float = 0.0
+    avg_context_recall: float = 0.0
+    num_questions: int = 0
+    individual_results: list[EvaluationResult] = field(default_factory=list)

--- a/src/evaluation/runner.py
+++ b/src/evaluation/runner.py
@@ -1,0 +1,219 @@
+"""Evaluation runner: orchestrates the full evaluation pipeline.
+
+Ties together test set generation, metric evaluation, cross-check comparison,
+and strategy comparison into a single workflow that produces a markdown report.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+
+from src.evaluation.compare_strategies import (
+    STRATEGY_COMBINATIONS,
+    compare_all_strategies,
+    format_comparison_table,
+)
+from src.evaluation.cross_check import run_cross_check, summarize_cross_check
+from src.evaluation.generate_test_set import (
+    generate_test_set,
+    load_test_set,
+    save_test_set,
+)
+from src.evaluation.models import (
+    StrategyResult,
+    TestQuestion,
+)
+
+
+def _generate_or_load_test_set(
+    transcripts: dict[str, str],
+    test_set_path: str | None = None,
+) -> list[TestQuestion]:
+    """Load an existing test set or generate a new one.
+
+    Args:
+        transcripts: Meeting transcripts (needed only for generation).
+        test_set_path: Path to existing test set JSON. If None or file doesn't
+            exist, generates a new test set.
+
+    Returns:
+        List of test questions.
+    """
+    if test_set_path and os.path.exists(test_set_path):
+        return load_test_set(test_set_path)
+
+    questions = generate_test_set(transcripts)
+
+    # Save for reuse
+    out_path = test_set_path or "data/test_set.json"
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    save_test_set(questions, out_path)
+
+    return questions
+
+
+def _format_test_set_summary(questions: list[TestQuestion]) -> str:
+    """Format a summary of the test set composition."""
+    by_category: dict[str, int] = {}
+    by_difficulty: dict[str, int] = {}
+    for q in questions:
+        by_category[q.category.value] = by_category.get(q.category.value, 0) + 1
+        by_difficulty[q.difficulty.value] = by_difficulty.get(q.difficulty.value, 0) + 1
+
+    lines = [
+        f"**Total questions:** {len(questions)}\n",
+        "**By category:**\n",
+    ]
+    for cat, count in sorted(by_category.items()):
+        lines.append(f"- {cat}: {count}")
+    lines.append("\n**By difficulty:**\n")
+    for diff, count in sorted(by_difficulty.items()):
+        lines.append(f"- {diff}: {count}")
+
+    return "\n".join(lines)
+
+
+def _format_cross_check_section(summary: dict) -> str:
+    """Format the cross-check results as markdown."""
+    if summary.get("total", 0) == 0:
+        return "No cross-check results available.\n"
+
+    lines = [
+        f"**Total comparisons:** {summary['total']}\n",
+        f"- RAG better: {summary['rag_better']} ({summary['rag_better_pct']:.1f}%)",
+        f"- Context stuffing better: {summary['context_stuffing_better']} "
+        f"({summary['context_stuffing_better_pct']:.1f}%)",
+        f"- Equivalent: {summary['equivalent']} ({summary['equivalent_pct']:.1f}%)\n",
+        f"**Average RAG score:** {summary['avg_rag_score']}",
+        f"**Average context-stuffing score:** {summary['avg_context_stuffing_score']}\n",
+    ]
+
+    # Per-category breakdown
+    by_cat = summary.get("by_category", {})
+    if by_cat:
+        lines.append("**By category:**\n")
+        lines.append("| Category | RAG Better | CS Better | Equivalent |")
+        lines.append("|----------|-----------|-----------|------------|")
+        for cat, counts in sorted(by_cat.items()):
+            lines.append(
+                f"| {cat} | {counts.get('RAG_BETTER', 0)} | "
+                f"{counts.get('CONTEXT_STUFFING_BETTER', 0)} | "
+                f"{counts.get('EQUIVALENT', 0)} |"
+            )
+
+    return "\n".join(lines)
+
+
+def generate_report(
+    questions: list[TestQuestion],
+    strategy_results: list[StrategyResult],
+    cross_check_summary: dict | None = None,
+) -> str:
+    """Generate a full markdown evaluation report.
+
+    Args:
+        questions: The test set used for evaluation.
+        strategy_results: Results from strategy comparison.
+        cross_check_summary: Optional cross-check summary dict.
+
+    Returns:
+        Markdown-formatted report string.
+    """
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+
+    sections = [
+        f"# Meeting Intelligence Evaluation Report\n\n_Generated: {now}_\n",
+        "## 1. Test Set Summary\n",
+        _format_test_set_summary(questions),
+        "\n## 2. Strategy Comparison\n",
+        format_comparison_table(strategy_results),
+    ]
+
+    # Find best strategy
+    if strategy_results:
+        best = max(
+            strategy_results,
+            key=lambda r: (r.avg_faithfulness + r.avg_relevancy + r.avg_context_precision + r.avg_context_recall) / 4,
+        )
+        composite = (
+            best.avg_faithfulness + best.avg_relevancy + best.avg_context_precision + best.avg_context_recall
+        ) / 4
+        sections.append(
+            f"\n**Best strategy:** {best.chunking_strategy} + {best.retrieval_strategy} "
+            f"(composite: {composite:.3f})\n"
+        )
+
+    if cross_check_summary:
+        sections.append("\n## 3. RAG vs Context Stuffing\n")
+        sections.append(_format_cross_check_section(cross_check_summary))
+
+    sections.append("\n---\n_Report generated by Meeting Intelligence Evaluation Framework_\n")
+
+    return "\n".join(sections)
+
+
+def run_evaluation(
+    transcripts: dict[str, str],
+    test_set_path: str | None = None,
+    output_dir: str = "data/eval_results",
+    strategies: list[tuple[str, str]] | None = None,
+    run_cross_check_eval: bool = True,
+    retrieval_strategy_for_cross_check: str = "hybrid",
+) -> str:
+    """Run the complete evaluation pipeline.
+
+    Args:
+        transcripts: Mapping of meeting_id -> transcript text.
+        test_set_path: Path to existing test set JSON, or None to generate.
+        output_dir: Directory to write results.
+        strategies: Strategy combinations to evaluate. Defaults to all four.
+        run_cross_check_eval: Whether to run RAG vs context-stuffing comparison.
+        retrieval_strategy_for_cross_check: Retrieval strategy for cross-check.
+
+    Returns:
+        Path to the generated markdown report.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Step 1: Load or generate test set
+    questions = _generate_or_load_test_set(transcripts, test_set_path)
+
+    # Step 2: Run strategy comparison
+    combos = strategies or STRATEGY_COMBINATIONS
+    strategy_results = compare_all_strategies(questions, combos)
+
+    # Save raw strategy results
+    strategy_data = [
+        {
+            "chunking_strategy": r.chunking_strategy,
+            "retrieval_strategy": r.retrieval_strategy,
+            "avg_faithfulness": r.avg_faithfulness,
+            "avg_relevancy": r.avg_relevancy,
+            "avg_context_precision": r.avg_context_precision,
+            "avg_context_recall": r.avg_context_recall,
+            "num_questions": r.num_questions,
+        }
+        for r in strategy_results
+    ]
+    with open(os.path.join(output_dir, "strategy_results.json"), "w") as f:
+        json.dump(strategy_data, f, indent=2)
+
+    # Step 3: Cross-check (optional)
+    cross_check_summary: dict | None = None
+    if run_cross_check_eval:
+        cc_results = run_cross_check(
+            questions, transcripts, retrieval_strategy_for_cross_check
+        )
+        cross_check_summary = summarize_cross_check(cc_results)
+        with open(os.path.join(output_dir, "cross_check_results.json"), "w") as f:
+            json.dump(cross_check_summary, f, indent=2, default=str)
+
+    # Step 4: Generate report
+    report = generate_report(questions, strategy_results, cross_check_summary)
+    report_path = os.path.join(output_dir, "evaluation_report.md")
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write(report)
+
+    return report_path

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,483 @@
+"""Tests for the evaluation framework.
+
+Tests cover metric calculation logic, cross-check categorization,
+test set generation parsing, and report generation format.
+API-calling tests are marked with @pytest.mark.expensive.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.evaluation.compare_strategies import format_comparison_table
+from src.evaluation.cross_check import summarize_cross_check
+from src.evaluation.generate_test_set import (
+    _parse_questions_json,
+    load_test_set,
+    save_test_set,
+)
+from src.evaluation.metrics import (
+    _clamp_score,
+    _format_contexts,
+    score_answer_relevancy,
+    score_context_precision,
+    score_context_recall,
+    score_faithfulness,
+)
+from src.evaluation.models import (
+    CrossCheckResult,
+    CrossCheckVerdict,
+    Difficulty,
+    MetricResult,
+    QuestionCategory,
+    StrategyResult,
+    TestQuestion,
+)
+from src.evaluation.runner import generate_report
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_question(**overrides) -> TestQuestion:
+    """Create a TestQuestion with sensible defaults."""
+    defaults = {
+        "question": "What was decided about the budget?",
+        "expected_answer": "The budget was set to $1M.",
+        "category": QuestionCategory.FACTUAL,
+        "difficulty": Difficulty.EASY,
+        "source_meeting_id": "meeting-1",
+        "question_id": "q-001",
+    }
+    defaults.update(overrides)
+    return TestQuestion(**defaults)
+
+
+def _mock_claude_response(text: str) -> MagicMock:
+    """Build a mock Anthropic messages.create response."""
+    mock_content = MagicMock()
+    mock_content.text = text
+    mock_response = MagicMock()
+    mock_response.content = [mock_content]
+    mock_response.model = "claude-sonnet-4-20250514"
+    mock_response.usage = MagicMock(input_tokens=100, output_tokens=50)
+    return mock_response
+
+
+# ── Test: Score clamping ─────────────────────────────────────────────────────
+
+
+class TestClampScore:
+    def test_within_range(self) -> None:
+        assert _clamp_score(0.5) == 0.5
+
+    def test_below_zero(self) -> None:
+        assert _clamp_score(-0.3) == 0.0
+
+    def test_above_one(self) -> None:
+        assert _clamp_score(1.5) == 1.0
+
+    def test_boundary_zero(self) -> None:
+        assert _clamp_score(0.0) == 0.0
+
+    def test_boundary_one(self) -> None:
+        assert _clamp_score(1.0) == 1.0
+
+
+# ── Test: Context formatting ────────────────────────────────────────────────
+
+
+class TestFormatContexts:
+    def test_formats_numbered(self) -> None:
+        result = _format_contexts(["chunk one", "chunk two"])
+        assert "[Chunk 1]: chunk one" in result
+        assert "[Chunk 2]: chunk two" in result
+
+    def test_empty_list(self) -> None:
+        assert _format_contexts([]) == ""
+
+
+# ── Test: Metrics with mocked Claude ────────────────────────────────────────
+
+
+class TestMetricsMocked:
+    """Test metric functions with mocked Claude API calls."""
+
+    @patch("src.evaluation.metrics.Anthropic")
+    def test_faithfulness_returns_metric_result(self, mock_anthropic_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = _mock_claude_response(
+            '{"score": 0.85, "reasoning": "Answer is well-grounded."}'
+        )
+
+        result = score_faithfulness("The budget is $1M.", ["Budget was set to $1M."])
+        assert isinstance(result, MetricResult)
+        assert result.score == 0.85
+        assert result.metric_name == "faithfulness"
+        assert "grounded" in result.reasoning
+
+    @patch("src.evaluation.metrics.Anthropic")
+    def test_answer_relevancy(self, mock_anthropic_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = _mock_claude_response(
+            '{"score": 0.9, "reasoning": "Directly answers the question."}'
+        )
+
+        result = score_answer_relevancy("What is the budget?", "The budget is $1M.")
+        assert result.score == 0.9
+        assert result.metric_name == "answer_relevancy"
+
+    @patch("src.evaluation.metrics.Anthropic")
+    def test_context_precision(self, mock_anthropic_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = _mock_claude_response(
+            '{"score": 0.7, "reasoning": "Most chunks relevant."}'
+        )
+
+        result = score_context_precision("Budget?", ["Budget info", "Irrelevant"])
+        assert result.score == 0.7
+        assert result.metric_name == "context_precision"
+
+    @patch("src.evaluation.metrics.Anthropic")
+    def test_context_recall(self, mock_anthropic_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = _mock_claude_response(
+            '{"score": 1.0, "reasoning": "All info present."}'
+        )
+
+        result = score_context_recall("Budget is $1M.", ["Budget set to $1M."])
+        assert result.score == 1.0
+        assert result.metric_name == "context_recall"
+
+    @patch("src.evaluation.metrics.Anthropic")
+    def test_handles_malformed_response(self, mock_anthropic_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = _mock_claude_response(
+            "This is not valid JSON at all"
+        )
+
+        result = score_faithfulness("answer", ["context"])
+        assert result.score == 0.0
+        assert "Failed" in result.reasoning
+
+    @patch("src.evaluation.metrics.Anthropic")
+    def test_handles_markdown_fences(self, mock_anthropic_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        mock_client.messages.create.return_value = _mock_claude_response(
+            '```json\n{"score": 0.75, "reasoning": "Good answer."}\n```'
+        )
+
+        result = score_faithfulness("answer", ["context"])
+        assert result.score == 0.75
+
+
+# ── Test: Cross-check summarization ─────────────────────────────────────────
+
+
+class TestCrossCheckSummarize:
+    def test_empty_results(self) -> None:
+        summary = summarize_cross_check([])
+        assert summary["total"] == 0
+
+    def test_counts_verdicts(self) -> None:
+        q = _make_question()
+        results = [
+            CrossCheckResult(
+                question=q,
+                rag_answer="a",
+                context_stuffing_answer="b",
+                verdict=CrossCheckVerdict.RAG_BETTER,
+                reasoning="RAG was more precise",
+                rag_score=0.9,
+                context_stuffing_score=0.6,
+            ),
+            CrossCheckResult(
+                question=q,
+                rag_answer="a",
+                context_stuffing_answer="b",
+                verdict=CrossCheckVerdict.CONTEXT_STUFFING_BETTER,
+                reasoning="CS had more info",
+                rag_score=0.5,
+                context_stuffing_score=0.8,
+            ),
+            CrossCheckResult(
+                question=q,
+                rag_answer="a",
+                context_stuffing_answer="b",
+                verdict=CrossCheckVerdict.EQUIVALENT,
+                reasoning="Both good",
+                rag_score=0.7,
+                context_stuffing_score=0.7,
+            ),
+        ]
+        summary = summarize_cross_check(results)
+        assert summary["total"] == 3
+        assert summary["rag_better"] == 1
+        assert summary["context_stuffing_better"] == 1
+        assert summary["equivalent"] == 1
+        assert abs(summary["rag_better_pct"] - 33.3) < 1.0
+
+    def test_average_scores(self) -> None:
+        q = _make_question()
+        results = [
+            CrossCheckResult(
+                question=q,
+                rag_answer="a",
+                context_stuffing_answer="b",
+                verdict=CrossCheckVerdict.RAG_BETTER,
+                reasoning="",
+                rag_score=0.8,
+                context_stuffing_score=0.4,
+            ),
+            CrossCheckResult(
+                question=q,
+                rag_answer="a",
+                context_stuffing_answer="b",
+                verdict=CrossCheckVerdict.RAG_BETTER,
+                reasoning="",
+                rag_score=0.6,
+                context_stuffing_score=0.2,
+            ),
+        ]
+        summary = summarize_cross_check(results)
+        assert summary["avg_rag_score"] == 0.7
+        assert summary["avg_context_stuffing_score"] == 0.3
+
+    def test_per_category_breakdown(self) -> None:
+        q_factual = _make_question(category=QuestionCategory.FACTUAL)
+        q_action = _make_question(category=QuestionCategory.ACTION_ITEMS)
+        results = [
+            CrossCheckResult(
+                question=q_factual,
+                rag_answer="a",
+                context_stuffing_answer="b",
+                verdict=CrossCheckVerdict.RAG_BETTER,
+                reasoning="",
+            ),
+            CrossCheckResult(
+                question=q_action,
+                rag_answer="a",
+                context_stuffing_answer="b",
+                verdict=CrossCheckVerdict.CONTEXT_STUFFING_BETTER,
+                reasoning="",
+            ),
+        ]
+        summary = summarize_cross_check(results)
+        assert "factual" in summary["by_category"]
+        assert summary["by_category"]["factual"]["RAG_BETTER"] == 1
+        assert summary["by_category"]["action_items"]["CONTEXT_STUFFING_BETTER"] == 1
+
+
+# ── Test: Test set JSON parsing ─────────────────────────────────────────────
+
+
+class TestParseQuestionsJSON:
+    def test_plain_json(self) -> None:
+        raw = '[{"question": "Q?", "expected_answer": "A."}]'
+        result = _parse_questions_json(raw)
+        assert len(result) == 1
+        assert result[0]["question"] == "Q?"
+
+    def test_with_markdown_fences(self) -> None:
+        raw = '```json\n[{"question": "Q?", "expected_answer": "A."}]\n```'
+        result = _parse_questions_json(raw)
+        assert len(result) == 1
+
+    def test_invalid_json_raises(self) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            _parse_questions_json("not json at all")
+
+
+# ── Test: Test set save/load round-trip ──────────────────────────────────────
+
+
+class TestTestSetPersistence:
+    def test_save_and_load(self) -> None:
+        questions = [
+            _make_question(question_id="q1"),
+            _make_question(
+                question_id="q2",
+                category=QuestionCategory.INFERENCE,
+                difficulty=Difficulty.HARD,
+            ),
+        ]
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            path = f.name
+
+        try:
+            save_test_set(questions, path)
+            loaded = load_test_set(path)
+            assert len(loaded) == 2
+            assert loaded[0].question_id == "q1"
+            assert loaded[1].category == QuestionCategory.INFERENCE
+            assert loaded[1].difficulty == Difficulty.HARD
+        finally:
+            os.unlink(path)
+
+
+# ── Test: Strategy comparison table ──────────────────────────────────────────
+
+
+class TestComparisonTable:
+    def test_format_produces_markdown(self) -> None:
+        results = [
+            StrategyResult(
+                chunking_strategy="naive",
+                retrieval_strategy="semantic",
+                avg_faithfulness=0.85,
+                avg_relevancy=0.9,
+                avg_context_precision=0.8,
+                avg_context_recall=0.75,
+                num_questions=50,
+            ),
+            StrategyResult(
+                chunking_strategy="speaker_turn",
+                retrieval_strategy="hybrid",
+                avg_faithfulness=0.88,
+                avg_relevancy=0.92,
+                avg_context_precision=0.83,
+                avg_context_recall=0.78,
+                num_questions=50,
+            ),
+        ]
+        table = format_comparison_table(results)
+        assert "| Chunking |" in table
+        assert "naive" in table
+        assert "speaker_turn" in table
+        assert "0.850" in table
+        assert "0.920" in table
+
+    def test_empty_results(self) -> None:
+        table = format_comparison_table([])
+        # Should still have the header
+        assert "| Chunking |" in table
+
+
+# ── Test: Report generation ──────────────────────────────────────────────────
+
+
+class TestReportGeneration:
+    def test_generates_markdown_report(self) -> None:
+        questions = [
+            _make_question(),
+            _make_question(
+                category=QuestionCategory.DECISIONS,
+                difficulty=Difficulty.MEDIUM,
+            ),
+        ]
+        strategy_results = [
+            StrategyResult(
+                chunking_strategy="naive",
+                retrieval_strategy="hybrid",
+                avg_faithfulness=0.8,
+                avg_relevancy=0.85,
+                avg_context_precision=0.75,
+                avg_context_recall=0.7,
+                num_questions=2,
+            ),
+        ]
+        report = generate_report(questions, strategy_results)
+        assert "# Meeting Intelligence Evaluation Report" in report
+        assert "Test Set Summary" in report
+        assert "Strategy Comparison" in report
+        assert "Total questions:** 2" in report
+        assert "naive" in report
+
+    def test_report_with_cross_check(self) -> None:
+        questions = [_make_question()]
+        strategy_results = [
+            StrategyResult(
+                chunking_strategy="naive",
+                retrieval_strategy="semantic",
+                avg_faithfulness=0.8,
+                avg_relevancy=0.85,
+                avg_context_precision=0.75,
+                avg_context_recall=0.7,
+                num_questions=1,
+            ),
+        ]
+        cross_check_summary = {
+            "total": 10,
+            "rag_better": 5,
+            "context_stuffing_better": 3,
+            "equivalent": 2,
+            "rag_better_pct": 50.0,
+            "context_stuffing_better_pct": 30.0,
+            "equivalent_pct": 20.0,
+            "avg_rag_score": 0.75,
+            "avg_context_stuffing_score": 0.65,
+            "by_category": {
+                "factual": {
+                    "RAG_BETTER": 3,
+                    "CONTEXT_STUFFING_BETTER": 1,
+                    "EQUIVALENT": 1,
+                }
+            },
+        }
+        report = generate_report(questions, strategy_results, cross_check_summary)
+        assert "RAG vs Context Stuffing" in report
+        assert "Total comparisons:** 10" in report
+        assert "50.0%" in report
+
+    def test_report_identifies_best_strategy(self) -> None:
+        questions = [_make_question()]
+        results = [
+            StrategyResult(
+                chunking_strategy="naive",
+                retrieval_strategy="semantic",
+                avg_faithfulness=0.5,
+                avg_relevancy=0.5,
+                avg_context_precision=0.5,
+                avg_context_recall=0.5,
+                num_questions=1,
+            ),
+            StrategyResult(
+                chunking_strategy="speaker_turn",
+                retrieval_strategy="hybrid",
+                avg_faithfulness=0.9,
+                avg_relevancy=0.9,
+                avg_context_precision=0.9,
+                avg_context_recall=0.9,
+                num_questions=1,
+            ),
+        ]
+        report = generate_report(questions, results)
+        assert "Best strategy:** speaker_turn + hybrid" in report
+
+
+# ── Test: Model enums ────────────────────────────────────────────────────────
+
+
+class TestModels:
+    def test_question_category_values(self) -> None:
+        assert QuestionCategory.FACTUAL.value == "factual"
+        assert QuestionCategory.MULTI_MEETING.value == "multi_meeting"
+
+    def test_difficulty_values(self) -> None:
+        assert Difficulty.EASY.value == "easy"
+        assert Difficulty.HARD.value == "hard"
+
+    def test_cross_check_verdict_values(self) -> None:
+        assert CrossCheckVerdict.RAG_BETTER.value == "RAG_BETTER"
+        assert CrossCheckVerdict.EQUIVALENT.value == "EQUIVALENT"
+
+    def test_metric_result_fields(self) -> None:
+        m = MetricResult(score=0.8, reasoning="Good", metric_name="test")
+        assert m.score == 0.8
+        assert m.metric_name == "test"
+
+    def test_strategy_result_defaults(self) -> None:
+        r = StrategyResult(chunking_strategy="naive", retrieval_strategy="semantic")
+        assert r.avg_faithfulness == 0.0
+        assert r.num_questions == 0
+        assert r.individual_results == []


### PR DESCRIPTION
## Summary
- Auto-generate Q&A test sets from meeting transcripts using Claude (150-250 questions across categories and difficulty levels)
- RAGAS-style metrics via Claude-as-judge: faithfulness, answer relevancy, context precision, context recall
- Cross-check evaluation: RAG vs context-stuffing comparison with verdict categorization
- Strategy comparison across all 4 combinations (naive/speaker_turn × semantic/hybrid) with markdown report
- Evaluation runner orchestrates full pipeline and generates markdown + JSON reports
- 31 new tests, all passing

## Test plan
- [x] `pytest tests/test_evaluation.py -v` — all 31 tests pass
- [x] Metric score clamping and edge cases tested
- [x] Cross-check summarization with per-category breakdowns tested
- [x] Report generation with strategy comparison tables tested

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)