### PR TITLE
fix: address code review findings — extract endpoint, hybrid search, lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cp .env.example .env
 # Add your API keys to .env
 
 # Install dependencies
-pip install -r requirements.txt
+pip install -e ".[dev]"
 
 # Database setup
 # Run the SQL migrations in supabase/migrations/ against your Supabase project

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 
+from src.api.routes.extraction import router as extraction_router
 from src.api.routes.ingest import router as ingest_router
 from src.api.routes.meetings import router as meetings_router
 from src.api.routes.query import router as query_router
@@ -13,6 +14,7 @@ app = FastAPI(
 app.include_router(ingest_router)
 app.include_router(query_router)
 app.include_router(meetings_router)
+app.include_router(extraction_router)
 
 
 @app.get("/health")

--- a/src/api/routes/extraction.py
+++ b/src/api/routes/extraction.py
@@ -1,0 +1,77 @@
+"""Extraction endpoint: trigger structured extraction for a meeting."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from src.api.models import ExtractedItemResponse, ExtractResponse
+from src.ingestion.storage import get_supabase_client
+
+router = APIRouter()
+
+
+@router.post("/api/meetings/{meeting_id}/extract", response_model=ExtractResponse)
+async def extract_meeting(meeting_id: str) -> ExtractResponse:
+    """Trigger structured extraction for a meeting.
+
+    Extracts action items, decisions, and key topics from the meeting
+    transcript using Claude and stores the results in the extracted_items table.
+    """
+    client = get_supabase_client()
+    result = client.table("meetings").select("*").eq("id", meeting_id).execute()
+
+    if not result.data:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+
+    m = result.data[0]
+    transcript = m.get("raw_transcript")
+    if not transcript:
+        raise HTTPException(
+            status_code=400,
+            detail="Meeting has no transcript to extract from",
+        )
+
+    from src.extraction.extractor import extract_and_store
+
+    items = extract_and_store(meeting_id, transcript)
+
+    return ExtractResponse(
+        meeting_id=meeting_id,
+        items_extracted=len(items),
+        action_items=[
+            ExtractedItemResponse(
+                item_type=i.item_type,
+                content=i.content,
+                assignee=i.assignee,
+                due_date=i.due_date,
+                speaker=i.speaker,
+                confidence=i.confidence,
+            )
+            for i in items
+            if i.item_type == "action_item"
+        ],
+        decisions=[
+            ExtractedItemResponse(
+                item_type=i.item_type,
+                content=i.content,
+                assignee=i.assignee,
+                due_date=i.due_date,
+                speaker=i.speaker,
+                confidence=i.confidence,
+            )
+            for i in items
+            if i.item_type == "decision"
+        ],
+        topics=[
+            ExtractedItemResponse(
+                item_type=i.item_type,
+                content=i.content,
+                assignee=i.assignee,
+                due_date=i.due_date,
+                speaker=i.speaker,
+                confidence=i.confidence,
+            )
+            for i in items
+            if i.item_type == "topic"
+        ],
+    )

--- a/src/pipeline_config.py
+++ b/src/pipeline_config.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 
 
-class ChunkingStrategy(str, Enum):
+class ChunkingStrategy(StrEnum):
     """Available chunking strategies for transcript ingestion."""
 
     NAIVE = "naive"
     SPEAKER_TURN = "speaker_turn"
 
 
-class RetrievalStrategy(str, Enum):
+class RetrievalStrategy(StrEnum):
     """Available retrieval strategies for querying."""
 
     SEMANTIC = "semantic"

--- a/src/retrieval/generation.py
+++ b/src/retrieval/generation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from anthropic import Anthropic
 
+from src.config import settings
+
 
 def generate_answer(question: str, context_chunks: list[dict]) -> dict:
     """Generate an answer using Claude with source attribution.
@@ -27,7 +29,7 @@ def generate_answer(question: str, context_chunks: list[dict]) -> dict:
 
     client = Anthropic()  # reads ANTHROPIC_API_KEY from env
     response = client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model=settings.llm_model,
         max_tokens=1024,
         system=(
             "You are a meeting intelligence assistant. Answer questions based "

--- a/src/retrieval/router.py
+++ b/src/retrieval/router.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from src.ingestion.storage import get_supabase_client
 
 
-class QueryType(str, Enum):
+class QueryType(StrEnum):
     """Classification of a user query."""
 
     STRUCTURED = "structured"

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -7,9 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.extraction.extractor import _parse_tool_response, extract_from_transcript
-from src.extraction.models import ExtractedItem
 from src.retrieval.router import QueryType, classify_query, format_structured_response
-
 
 # ---------------------------------------------------------------------------
 # Extraction tests
@@ -280,7 +278,7 @@ class TestExtractEndpoint:
         from src.api.main import app
 
         client = TestClient(app, raise_server_exceptions=False)
-        response = client.get("/api/meetings/00000000-0000-0000-0000-000000000000/extract")
+        response = client.post("/api/meetings/00000000-0000-0000-0000-000000000000/extract")
         # Without Supabase: 500; with Supabase and missing ID: 404
         assert response.status_code in [404, 500]
 


### PR DESCRIPTION
## Summary
Fixes from comprehensive code review audit:

**Critical:**
- Wire up POST `/api/meetings/{id}/extract` endpoint (was defined in models but never routed)
- Fix `hybrid_search` to support `meeting_id` filtering (was silently returning all meetings)

**Important:**
- Consolidate duplicate `get_supabase_client()` — single source in `src/ingestion/storage`
- Use `settings.llm_model` in `generation.py` instead of hardcoded model name
- Fix 3 ruff lint errors (StrEnum migration, import sorting, unused import)
- Fix README: `pip install -r requirements.txt` → `pip install -e ".[dev]"`
- Add 50MB file upload size limit to ingest endpoint

## Test plan
- [x] `pytest tests/ -x -v` — all 108 tests pass
- [x] `ruff check src/ tests/ scripts/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)