### PR TITLE
feat: contextual retrieval (#66)

### DIFF
--- a/src/api/routes/ingest.py
+++ b/src/api/routes/ingest.py
@@ -91,6 +91,7 @@ async def ingest(
     file: Annotated[UploadFile, File(...)],
     title: Annotated[str, Form()] = "Untitled Meeting",
     chunking_strategy: Annotated[str, Form()] = "speaker_turn",
+    contextual_retrieval: Annotated[bool, Form()] = False,
 ) -> IngestResponse | BatchIngestResponse:
     """Upload a transcript file and run the ingestion pipeline.
 
@@ -107,6 +108,8 @@ async def ingest(
       without a key.
 
     Issue #34: zip bulk upload + Teams VTT support.
+    Issue #66: set ``contextual_retrieval=true`` to prepend Claude-generated context to each
+    chunk before embedding. Improves retrieval quality; adds ~1 Haiku API call per chunk.
     """
     # Enforce file size limit
     raw = await file.read()
@@ -150,7 +153,14 @@ async def ingest(
         format_map = {"vtt": "vtt", "txt": "text", "json": "json"}
         transcript_format = format_map.get(ext, "text")
 
-    meeting_id = ingest_transcript(content, transcript_format, title, strategy, user_id=user_id)
+    meeting_id = ingest_transcript(
+        content,
+        transcript_format,
+        title,
+        strategy,
+        user_id=user_id,
+        contextual_retrieval=contextual_retrieval,
+    )
 
     # Get chunk count
     client = get_supabase_client()

--- a/src/ingestion/embeddings.py
+++ b/src/ingestion/embeddings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import anthropic
+from anthropic.types import TextBlock
 from openai import OpenAI
 
 from src.config import settings
@@ -35,3 +37,69 @@ def embed_chunks(chunks: list[Chunk]) -> list[tuple[Chunk, list[float]]]:
     texts = [c.content for c in chunks]
     embeddings = embed_texts(texts)
     return list(zip(chunks, embeddings, strict=True))
+
+
+def generate_chunk_context(chunk: Chunk, meeting_title: str) -> str:
+    """Call Claude Haiku to generate retrieval context for a chunk.
+
+    Generates a 1-2 sentence description that provides document-level context
+    for the chunk. This is prepended to the chunk text before embedding so
+    that the embedding captures both document context and local content
+    (contextual retrieval, per Anthropic research).
+
+    Issue #66: ~$0.001 per chunk at Haiku pricing.
+
+    Args:
+        chunk: The chunk whose content needs contextualising.
+        meeting_title: Human-readable title of the meeting this chunk belongs to.
+
+    Returns:
+        A concise 1-2 sentence context string.
+    """
+    client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+    prompt = (
+        f"Meeting title: {meeting_title}\n\n"
+        f"Chunk text:\n{chunk.content}\n\n"
+        "Write 1-2 sentences of context to help retrieve this chunk when searching the meeting. "
+        "Include the meeting topic, speaker if known, and what this excerpt is about. Be concise."
+    )
+    response = client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=100,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    # Narrow union content block to TextBlock — plain text prompt always returns TextBlock. (#66)
+    block = response.content[0]
+    if not isinstance(block, TextBlock):
+        raise ValueError(f"Expected TextBlock from Claude, got {type(block).__name__}")
+    return block.text.strip()
+
+
+def embed_chunks_with_context(
+    chunks: list[Chunk],
+    meeting_title: str,
+) -> list[tuple[Chunk, list[float]]]:
+    """Embed chunks with Claude-generated context prepended to each chunk text.
+
+    For each chunk, calls ``generate_chunk_context()`` to produce a short
+    retrieval-oriented summary, prepends it to the chunk content, and embeds
+    the enriched text.  The original ``chunk.content`` is NOT modified — only
+    the text sent to the embedding API is enriched.
+
+    Issue #66: opt-in via ``PipelineConfig.contextual_retrieval``.
+
+    Args:
+        chunks: Chunks to embed.
+        meeting_title: Human-readable meeting title, forwarded to Claude for context.
+
+    Returns:
+        List of ``(Chunk, embedding_vector)`` tuples (same structure as
+        ``embed_chunks()`` for drop-in compatibility in the pipeline).
+    """
+    results: list[tuple[Chunk, list[float]]] = []
+    for chunk in chunks:
+        context = generate_chunk_context(chunk, meeting_title)
+        enriched_text = f"{context}\n\n{chunk.content}"
+        embedding = embed_texts([enriched_text])[0]
+        results.append((chunk, embedding))
+    return results

--- a/src/ingestion/pipeline.py
+++ b/src/ingestion/pipeline.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 
 from src.ingestion.chunking import naive_chunk, speaker_turn_chunk
-from src.ingestion.embeddings import embed_chunks
+from src.ingestion.embeddings import embed_chunks, embed_chunks_with_context
 from src.ingestion.parsers import parse_transcript
 from src.ingestion.storage import get_supabase_client, store_chunks, store_meeting
 from src.pipeline_config import ChunkingStrategy
@@ -20,6 +20,7 @@ def ingest_transcript(
     chunking_strategy: str | ChunkingStrategy = ChunkingStrategy.SPEAKER_TURN,
     extract: bool = False,
     user_id: str | None = None,
+    contextual_retrieval: bool = False,
 ) -> str:
     """Full ingestion pipeline: parse -> chunk -> embed -> store (-> extract).
 
@@ -32,6 +33,9 @@ def ingest_transcript(
         user_id: Authenticated user's UUID. Stored on the meeting row for
             per-user isolation. If ``None``, the row is created without an
             owner (legacy behaviour, will be filtered out after migration).
+        contextual_retrieval: If True, each chunk is enriched with a
+            Claude-generated 1-2 sentence context before embedding (Issue #66).
+            Adds one Claude Haiku API call per chunk at ingest time.
 
     Returns:
         The newly created meeting ID.
@@ -50,7 +54,13 @@ def ingest_transcript(
         chunks = speaker_turn_chunk(segments)
 
     # 3. Embed
-    chunks_with_embeddings = embed_chunks(chunks)
+    # Issue #66: contextual retrieval enriches each chunk with a Claude-generated
+    # context sentence before embedding, improving retrieval quality at the cost
+    # of one extra Haiku API call per chunk.
+    if contextual_retrieval:
+        chunks_with_embeddings = embed_chunks_with_context(chunks, title)
+    else:
+        chunks_with_embeddings = embed_chunks(chunks)
 
     # 4. Store
     client = get_supabase_client()

--- a/src/pipeline_config.py
+++ b/src/pipeline_config.py
@@ -30,3 +30,7 @@ class PipelineConfig:
 
     chunking_strategy: ChunkingStrategy = ChunkingStrategy.SPEAKER_TURN
     retrieval_strategy: RetrievalStrategy = RetrievalStrategy.HYBRID
+    # Issue #66: when True, each chunk is contextualised with a Claude-generated
+    # 1-2 sentence summary before embedding (contextual retrieval).
+    # Off by default to preserve existing behaviour and avoid extra API cost.
+    contextual_retrieval: bool = False

--- a/tests/test_contextual_retrieval.py
+++ b/tests/test_contextual_retrieval.py
@@ -1,0 +1,367 @@
+"""Unit tests for contextual retrieval — Issue #66.
+
+All tests mock external API calls (Anthropic Claude, OpenAI embeddings).
+No live API calls are made in this file.  Tests requiring real Claude calls
+are marked @pytest.mark.expensive.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from anthropic.types import TextBlock
+
+from src.ingestion.models import Chunk
+
+# ---------------------------------------------------------------------------
+# generate_chunk_context
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateChunkContext:
+    """Tests for generate_chunk_context() in src/ingestion/embeddings.py."""
+
+    @patch("src.ingestion.embeddings.anthropic.Anthropic")
+    def test_calls_claude_haiku_and_returns_text(self, mock_anthropic_cls: MagicMock) -> None:
+        """generate_chunk_context calls Claude and returns the response text."""
+        mock_client = mock_anthropic_cls.return_value
+        mock_client.messages.create.return_value.content = [
+            TextBlock(type="text", text="This chunk is from a Budget Meeting discussing Q4 allocations.")
+        ]
+
+        from src.ingestion.embeddings import generate_chunk_context
+
+        chunk = Chunk(content="The motion to allocate funds was passed unanimously.", chunk_index=0)
+        result = generate_chunk_context(chunk, "Budget Meeting")
+
+        assert result == "This chunk is from a Budget Meeting discussing Q4 allocations."
+        mock_client.messages.create.assert_called_once()
+
+    @patch("src.ingestion.embeddings.anthropic.Anthropic")
+    def test_passes_meeting_title_in_prompt(self, mock_anthropic_cls: MagicMock) -> None:
+        """generate_chunk_context includes the meeting title in the Claude prompt."""
+        mock_client = mock_anthropic_cls.return_value
+        mock_client.messages.create.return_value.content = [TextBlock(type="text", text="Context.")]
+
+        from src.ingestion.embeddings import generate_chunk_context
+
+        chunk = Chunk(content="Some text.", chunk_index=0)
+        generate_chunk_context(chunk, "Annual Review 2025")
+
+        call_kwargs = mock_client.messages.create.call_args
+        # Extract the messages argument to verify the title is present
+        messages = call_kwargs[1]["messages"] if call_kwargs[1] else call_kwargs[0][2]
+        user_message_content = messages[0]["content"]
+        assert "Annual Review 2025" in user_message_content
+
+    @patch("src.ingestion.embeddings.anthropic.Anthropic")
+    def test_passes_chunk_content_in_prompt(self, mock_anthropic_cls: MagicMock) -> None:
+        """generate_chunk_context includes the chunk content in the Claude prompt."""
+        mock_client = mock_anthropic_cls.return_value
+        mock_client.messages.create.return_value.content = [TextBlock(type="text", text="Context.")]
+
+        from src.ingestion.embeddings import generate_chunk_context
+
+        chunk = Chunk(content="The budget was approved for Q4.", chunk_index=0)
+        generate_chunk_context(chunk, "Finance Meeting")
+
+        call_kwargs = mock_client.messages.create.call_args
+        messages = call_kwargs[1]["messages"] if call_kwargs[1] else call_kwargs[0][2]
+        user_message_content = messages[0]["content"]
+        assert "The budget was approved for Q4." in user_message_content
+
+    @patch("src.ingestion.embeddings.anthropic.Anthropic")
+    def test_strips_whitespace_from_response(self, mock_anthropic_cls: MagicMock) -> None:
+        """generate_chunk_context strips leading/trailing whitespace from the response."""
+        mock_client = mock_anthropic_cls.return_value
+        mock_client.messages.create.return_value.content = [
+            TextBlock(type="text", text="  Context with extra whitespace.  \n")
+        ]
+
+        from src.ingestion.embeddings import generate_chunk_context
+
+        chunk = Chunk(content="Some text.", chunk_index=0)
+        result = generate_chunk_context(chunk, "Meeting")
+        assert result == "Context with extra whitespace."
+
+    @patch("src.ingestion.embeddings.anthropic.Anthropic")
+    def test_uses_haiku_model(self, mock_anthropic_cls: MagicMock) -> None:
+        """generate_chunk_context uses the claude-haiku-4-5 model (cheap, fast)."""
+        mock_client = mock_anthropic_cls.return_value
+        mock_client.messages.create.return_value.content = [TextBlock(type="text", text="Context.")]
+
+        from src.ingestion.embeddings import generate_chunk_context
+
+        chunk = Chunk(content="Text.", chunk_index=0)
+        generate_chunk_context(chunk, "Meeting")
+
+        call_kwargs = mock_client.messages.create.call_args
+        model_used = call_kwargs[1].get("model") or call_kwargs[0][0]
+        assert "haiku" in model_used.lower()
+
+
+# ---------------------------------------------------------------------------
+# embed_chunks_with_context
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedChunksWithContext:
+    """Tests for embed_chunks_with_context() in src/ingestion/embeddings.py."""
+
+    @patch("src.ingestion.embeddings.embed_texts")
+    @patch("src.ingestion.embeddings.generate_chunk_context")
+    def test_returns_chunk_embedding_pairs(
+        self, mock_gen_ctx: MagicMock, mock_embed: MagicMock
+    ) -> None:
+        """embed_chunks_with_context returns (Chunk, embedding) tuples."""
+        mock_gen_ctx.return_value = "This is retrieval context."
+        mock_embed.return_value = [[0.1, 0.2, 0.3]]
+
+        from src.ingestion.embeddings import embed_chunks_with_context
+
+        chunks = [Chunk(content="Meeting text here.", chunk_index=0)]
+        result = embed_chunks_with_context(chunks, "Test Meeting")
+
+        assert len(result) == 1
+        chunk_out, embedding = result[0]
+        assert chunk_out is chunks[0]
+        assert embedding == [0.1, 0.2, 0.3]
+
+    @patch("src.ingestion.embeddings.embed_texts")
+    @patch("src.ingestion.embeddings.generate_chunk_context")
+    def test_enriched_text_contains_context_and_content(
+        self, mock_gen_ctx: MagicMock, mock_embed: MagicMock
+    ) -> None:
+        """embed_texts is called with context prepended to chunk content."""
+        mock_gen_ctx.return_value = "Budget context sentence."
+        mock_embed.return_value = [[0.5, 0.6]]
+
+        from src.ingestion.embeddings import embed_chunks_with_context
+
+        chunk = Chunk(content="The budget was approved.", chunk_index=0)
+        embed_chunks_with_context([chunk], "Budget Meeting")
+
+        call_args = mock_embed.call_args
+        texts_arg = call_args[0][0]  # first positional arg is the texts list
+        assert len(texts_arg) == 1
+        enriched = texts_arg[0]
+        assert "Budget context sentence." in enriched
+        assert "The budget was approved." in enriched
+
+    @patch("src.ingestion.embeddings.embed_texts")
+    @patch("src.ingestion.embeddings.generate_chunk_context")
+    def test_original_chunk_content_unchanged(
+        self, mock_gen_ctx: MagicMock, mock_embed: MagicMock
+    ) -> None:
+        """embed_chunks_with_context does NOT modify the original chunk.content."""
+        mock_gen_ctx.return_value = "Prepended context."
+        mock_embed.return_value = [[0.1, 0.2]]
+
+        from src.ingestion.embeddings import embed_chunks_with_context
+
+        chunk = Chunk(content="Original chunk text.", chunk_index=0)
+        embed_chunks_with_context([chunk], "Meeting")
+
+        # The chunk object should be unmodified
+        assert chunk.content == "Original chunk text."
+
+    @patch("src.ingestion.embeddings.embed_texts")
+    @patch("src.ingestion.embeddings.generate_chunk_context")
+    def test_handles_multiple_chunks(
+        self, mock_gen_ctx: MagicMock, mock_embed: MagicMock
+    ) -> None:
+        """embed_chunks_with_context processes each chunk independently."""
+        mock_gen_ctx.side_effect = ["Context A.", "Context B."]
+        mock_embed.side_effect = [[[0.1, 0.2]], [[0.3, 0.4]]]
+
+        from src.ingestion.embeddings import embed_chunks_with_context
+
+        chunks = [
+            Chunk(content="Chunk A text.", chunk_index=0),
+            Chunk(content="Chunk B text.", chunk_index=1),
+        ]
+        result = embed_chunks_with_context(chunks, "Meeting")
+
+        assert len(result) == 2
+        assert result[0][0] is chunks[0]
+        assert result[1][0] is chunks[1]
+        assert mock_gen_ctx.call_count == 2
+        assert mock_embed.call_count == 2
+
+    @patch("src.ingestion.embeddings.embed_texts")
+    @patch("src.ingestion.embeddings.generate_chunk_context")
+    def test_empty_chunks_returns_empty_list(
+        self, mock_gen_ctx: MagicMock, mock_embed: MagicMock
+    ) -> None:
+        """embed_chunks_with_context returns [] when given an empty chunk list."""
+        from src.ingestion.embeddings import embed_chunks_with_context
+
+        result = embed_chunks_with_context([], "Meeting")
+        assert result == []
+        mock_gen_ctx.assert_not_called()
+        mock_embed.assert_not_called()
+
+    @patch("src.ingestion.embeddings.embed_texts")
+    @patch("src.ingestion.embeddings.generate_chunk_context")
+    def test_meeting_title_forwarded_to_generate_context(
+        self, mock_gen_ctx: MagicMock, mock_embed: MagicMock
+    ) -> None:
+        """embed_chunks_with_context passes the meeting title to generate_chunk_context."""
+        mock_gen_ctx.return_value = "Context."
+        mock_embed.return_value = [[0.1]]
+
+        from src.ingestion.embeddings import embed_chunks_with_context
+
+        chunk = Chunk(content="Text.", chunk_index=0)
+        embed_chunks_with_context([chunk], "Specific Meeting Title")
+
+        mock_gen_ctx.assert_called_once_with(chunk, "Specific Meeting Title")
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration — ingest_transcript contextual_retrieval flag
+# ---------------------------------------------------------------------------
+
+
+class TestIngestTranscriptContextualRetrievalFlag:
+    """Tests that ingest_transcript routes to the right embed function."""
+
+    @patch("src.ingestion.pipeline.store_chunks")
+    @patch("src.ingestion.pipeline.store_meeting")
+    @patch("src.ingestion.pipeline.get_supabase_client")
+    @patch("src.ingestion.pipeline.embed_chunks_with_context")
+    @patch("src.ingestion.pipeline.embed_chunks")
+    def test_contextual_retrieval_false_uses_embed_chunks(
+        self,
+        mock_embed_chunks: MagicMock,
+        mock_embed_ctx: MagicMock,
+        mock_get_client: MagicMock,
+        mock_store_meeting: MagicMock,
+        mock_store_chunks: MagicMock,
+    ) -> None:
+        """When contextual_retrieval=False, embed_chunks is called (not embed_chunks_with_context)."""
+        mock_embed_chunks.return_value = []
+        mock_store_meeting.return_value = "00000000-0000-0000-0000-000000000001"
+
+        from src.ingestion.pipeline import ingest_transcript
+
+        ingest_transcript(
+            content="Speaker 1: Hello.",
+            format="text",
+            title="Test Meeting",
+            contextual_retrieval=False,
+        )
+
+        mock_embed_chunks.assert_called_once()
+        mock_embed_ctx.assert_not_called()
+
+    @patch("src.ingestion.pipeline.store_chunks")
+    @patch("src.ingestion.pipeline.store_meeting")
+    @patch("src.ingestion.pipeline.get_supabase_client")
+    @patch("src.ingestion.pipeline.embed_chunks_with_context")
+    @patch("src.ingestion.pipeline.embed_chunks")
+    def test_contextual_retrieval_true_uses_embed_chunks_with_context(
+        self,
+        mock_embed_chunks: MagicMock,
+        mock_embed_ctx: MagicMock,
+        mock_get_client: MagicMock,
+        mock_store_meeting: MagicMock,
+        mock_store_chunks: MagicMock,
+    ) -> None:
+        """When contextual_retrieval=True, embed_chunks_with_context is called."""
+        mock_embed_ctx.return_value = []
+        mock_store_meeting.return_value = "00000000-0000-0000-0000-000000000002"
+
+        from src.ingestion.pipeline import ingest_transcript
+
+        ingest_transcript(
+            content="Speaker 1: Hello.",
+            format="text",
+            title="Test Meeting",
+            contextual_retrieval=True,
+        )
+
+        mock_embed_ctx.assert_called_once()
+        mock_embed_chunks.assert_not_called()
+
+    @patch("src.ingestion.pipeline.store_chunks")
+    @patch("src.ingestion.pipeline.store_meeting")
+    @patch("src.ingestion.pipeline.get_supabase_client")
+    @patch("src.ingestion.pipeline.embed_chunks_with_context")
+    @patch("src.ingestion.pipeline.embed_chunks")
+    def test_contextual_retrieval_passes_title_to_embed(
+        self,
+        mock_embed_chunks: MagicMock,
+        mock_embed_ctx: MagicMock,
+        mock_get_client: MagicMock,
+        mock_store_meeting: MagicMock,
+        mock_store_chunks: MagicMock,
+    ) -> None:
+        """When contextual_retrieval=True, the meeting title is forwarded to embed_chunks_with_context."""
+        mock_embed_ctx.return_value = []
+        mock_store_meeting.return_value = "00000000-0000-0000-0000-000000000003"
+
+        from src.ingestion.pipeline import ingest_transcript
+
+        ingest_transcript(
+            content="Speaker 1: Hello.",
+            format="text",
+            title="Q4 Budget Review",
+            contextual_retrieval=True,
+        )
+
+        call_args = mock_embed_ctx.call_args
+        # Second positional arg (or keyword arg) should be the title
+        _, kwargs = call_args
+        # call is embed_chunks_with_context(chunks, title)
+        title_passed = call_args[0][1] if len(call_args[0]) > 1 else kwargs.get("meeting_title")
+        assert title_passed == "Q4 Budget Review"
+
+    @patch("src.ingestion.pipeline.store_chunks")
+    @patch("src.ingestion.pipeline.store_meeting")
+    @patch("src.ingestion.pipeline.get_supabase_client")
+    @patch("src.ingestion.pipeline.embed_chunks")
+    def test_default_uses_standard_embedding(
+        self,
+        mock_embed_chunks: MagicMock,
+        mock_get_client: MagicMock,
+        mock_store_meeting: MagicMock,
+        mock_store_chunks: MagicMock,
+    ) -> None:
+        """Default contextual_retrieval=False preserves existing pipeline behaviour."""
+        mock_embed_chunks.return_value = []
+        mock_store_meeting.return_value = "00000000-0000-0000-0000-000000000004"
+
+        from src.ingestion.pipeline import ingest_transcript
+
+        # Call without contextual_retrieval keyword — should default to False
+        ingest_transcript(
+            content="Speaker 1: Hello.",
+            format="text",
+            title="Test Meeting",
+        )
+
+        mock_embed_chunks.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# PipelineConfig
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineConfigContextualRetrieval:
+    """Tests for the contextual_retrieval field on PipelineConfig."""
+
+    def test_default_is_false(self) -> None:
+        """PipelineConfig.contextual_retrieval defaults to False."""
+        from src.pipeline_config import PipelineConfig
+
+        config = PipelineConfig()
+        assert config.contextual_retrieval is False
+
+    def test_can_be_set_to_true(self) -> None:
+        """PipelineConfig.contextual_retrieval can be set to True."""
+        from src.pipeline_config import PipelineConfig
+
+        config = PipelineConfig(contextual_retrieval=True)
+        assert config.contextual_retrieval is True


### PR DESCRIPTION
## Summary

Implements contextual retrieval per [Anthropic research](https://www.anthropic.com/news/contextual-retrieval) — before embedding each chunk, a Claude Haiku call generates a 1-2 sentence document-level context summary that is prepended to the chunk text. The original `chunk.content` is unchanged; only the text sent to the OpenAI embedding API is enriched.

- **`generate_chunk_context(chunk, meeting_title)`** — calls `claude-haiku-4-5-20251001` to generate per-chunk retrieval context (~$0.001/chunk)
- **`embed_chunks_with_context(chunks, meeting_title)`** — drop-in replacement for `embed_chunks()` that enriches text before embedding
- **`PipelineConfig.contextual_retrieval: bool = False`** — off by default, opt-in per ingest
- **`/api/ingest`** — accepts new `contextual_retrieval` (bool Form field); wires through to `ingest_transcript()`
- **17 mocked unit tests** in `tests/test_contextual_retrieval.py` covering both functions and pipeline routing

## Test plan

- [x] `pytest tests/ -m "not expensive" -q` — 155 passed, 3 deselected
- [x] `ruff check src/ tests/` — all checks passed
- [x] `mypy src/ingestion/embeddings.py src/ingestion/pipeline.py src/pipeline_config.py` — clean
- [ ] Manual: start API on port 8180 (`PORT=8180 make api`) and ingest with `contextual_retrieval=true`

## Notes

This is a **demo branch** — merge not required. The `contextual_retrieval=false` default preserves all existing behaviour with zero extra API cost.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)